### PR TITLE
Uses a livereload plugin instead of relying on reloadPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,6 @@ import HotReloadMixin from 'ember-cli-hot-loader/mixins/hot-reload-resolver';
 export default Resolver.extend(HotReloadMixin);
 ```
 
-Add the development settings for ember-devtools to your config/environment.js
-
-```js
-'ember-devtools': {
-  global: 'devtools',
-  enabled: environment === 'development'
-}
-```
-
 ## How to use this addon
 
 1) Your app must be using pods

--- a/README.md
+++ b/README.md
@@ -49,20 +49,6 @@ export default Ember.Component.extend({
 });
 ```
 
-3) Update the livereload.js file in `node_modules` by adding `path` as an argument to the line `return this.reloadPage();`
-
-```
-vim node_modules/ember-cli/node_modules/tiny-lr/node_modules/livereload-js/dist/livereload.js
-```
-
-Until the livereload issue below is resolved you will need to hack the reloadPage function to provide path
-
-```
-return this.reloadPage(path);
-```
-
-https://github.com/livereload/livereload-js/issues/58
-
 ## Example application
 
 https://github.com/toranb/ember-redux-ddau-example/commit/81d5c4d254605dadf5dbf990138fb9f0a42b3a93

--- a/addon/instance-initializers/hot-loader-livereload-plugin.js
+++ b/addon/instance-initializers/hot-loader-livereload-plugin.js
@@ -1,15 +1,12 @@
-(function () {
-  if (!window.LiveReload) {
-    return;
-  }
-  var appName = document.getElementById('ember-cli-hot-loader-plugin').getAttribute('data-app-name');
+function createPlugin (appName, hotReloadService) {
+
   function Plugin (window, host) {
     this.window = window;
     this.host = host;
-  };
+  }
   Plugin.identifier = 'ember-hot-reload';
   Plugin.version = '1.0'; // Just following the example, this might not be even used
-  Plugin.prototype.reload = function(path, options) {
+  Plugin.prototype.reload = function(path) {
         // TODO: is this needed? Consider removing since it might have undersired effects
     window.runningTests = true;
     var tags = document.getElementsByTagName('script');
@@ -22,11 +19,11 @@
     script.onload = function() {
       setTimeout(function() {
         window.runningTests = false;
-        window.devtools.service('hot-reload').trigger('newChanges', path);
+        hotReloadService.trigger('newChanges', path);
       }, 10);
     };
     script.type = 'text/javascript';
-    script.src = '/assets/' + appName + '.js';
+    script.src = `/assets/${appName}.js`;
     document.body.appendChild(script);
 
     return true;
@@ -36,5 +33,19 @@
       disable: false
     };
   };
+
+  return Plugin;
+}
+
+export function initialize(appInstance) {
+  if (!window.LiveReload) {
+    return;
+  }
+  const Plugin = createPlugin(appInstance.base.name, appInstance.lookup('service:hot-reload'));
   window.LiveReload.addPlugin(Plugin);
-})();
+}
+
+export default {
+  name: 'hot-loader-livereload-plugin',
+  initialize
+};

--- a/app/instance-initializers/hot-loader-livereload-plugin.js
+++ b/app/instance-initializers/hot-loader-livereload-plugin.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-cli-hot-loader/instance-initializers/hot-loader-livereload-plugin';

--- a/index.js
+++ b/index.js
@@ -11,20 +11,5 @@ module.exports = {
         this._super.included(app);
         // TODO: consider removing this since it adds an unnecessary runtime dependency to all apps
         app.import(app.bowerDirectory + '/ember/ember-template-compiler.js');
-    },
-    isDevelopingAddon () {
-      return true;
-    },
-    contentFor: function(type, config) {
-        var environment = this.app.env.toString();
-        var appName = this.app.name;
-        if (type === 'body-footer') {
-            // TODO: find a better place other than body-footer or add a file instead of inline
-            if (environment === 'development') {
-                //hack the reloadPage to take path for now*
-                //https://github.com/livereload/livereload-js/issues/58
-                return '<script id="ember-cli-hot-loader-plugin" data-app-name="' + appName + '" src="' + config.rootURL + 'ember-cli-hot-loader/livereload-plugin.js"></script>';
-            }
-        }
     }
 };

--- a/index.js
+++ b/index.js
@@ -9,32 +9,21 @@ module.exports = {
     },
     included (app) {
         this._super.included(app);
+        // TODO: consider removing this since it adds an unnecessary runtime dependency to all apps
         app.import(app.bowerDirectory + '/ember/ember-template-compiler.js');
     },
-    contentFor: function(type) {
+    isDevelopingAddon () {
+      return true;
+    },
+    contentFor: function(type, config) {
         var environment = this.app.env.toString();
         var appName = this.app.name;
         if (type === 'body-footer') {
+            // TODO: find a better place other than body-footer or add a file instead of inline
             if (environment === 'development') {
                 //hack the reloadPage to take path for now*
                 //https://github.com/livereload/livereload-js/issues/58
-                return "<script>window.LiveReload.reloader.reloadPage = function(path) {" +
-                "window.runningTests = true;" +
-                "var tags = document.getElementsByTagName('script');" +
-                "for (var i = tags.length; i >= 0; i--){" +
-                "if (tags[i] && tags[i].getAttribute('src') != null && tags[i].getAttribute('src').indexOf('" + appName + "') != -1)" +
-                "tags[i].parentNode.removeChild(tags[i]);" +
-                "}" +
-                "var script = document.createElement('script');" +
-                "script.onload = function() {" +
-                "setTimeout(function() {" +
-                "window.runningTests = false;" +
-                "window.devtools.service('hot-reload').trigger('newChanges', path);" +
-                "}, 10)};" +
-                "script.type = 'text/javascript';" +
-                "script.src = '/assets/" + appName + ".js';" +
-                "document.body.appendChild(script);" +
-                "}</script>";
+                return '<script id="ember-cli-hot-loader-plugin" data-app-name="' + appName + '" src="' + config.rootURL + 'ember-cli-hot-loader/livereload-plugin.js"></script>';
             }
         }
     }

--- a/public/livereload-plugin.js
+++ b/public/livereload-plugin.js
@@ -1,7 +1,16 @@
 (function () {
+  if (!window.LiveReload) {
+    return;
+  }
   var appName = document.getElementById('ember-cli-hot-loader-plugin').getAttribute('data-app-name');
-  window.LiveReload.reloader.reloadPage = function(path) {
-    // TODO: is this needed? Consider removing since it might have undersired effects
+  function Plugin (window, host) {
+    this.window = window;
+    this.host = host;
+  };
+  Plugin.identifier = 'ember-hot-reload';
+  Plugin.version = '1.0'; // Just following the example, this might not be even used
+  Plugin.prototype.reload = function(path, options) {
+        // TODO: is this needed? Consider removing since it might have undersired effects
     window.runningTests = true;
     var tags = document.getElementsByTagName('script');
     for (var i = tags.length; i >= 0; i--){
@@ -19,5 +28,13 @@
     script.type = 'text/javascript';
     script.src = '/assets/' + appName + '.js';
     document.body.appendChild(script);
+
+    return true;
   };
+  Plugin.prototype.analyze = function() {
+    return {
+      disable: false
+    };
+  };
+  window.LiveReload.addPlugin(Plugin);
 })();

--- a/public/livereload-plugin.js
+++ b/public/livereload-plugin.js
@@ -1,0 +1,23 @@
+(function () {
+  var appName = document.getElementById('ember-cli-hot-loader-plugin').getAttribute('data-app-name');
+  window.LiveReload.reloader.reloadPage = function(path) {
+    // TODO: is this needed? Consider removing since it might have undersired effects
+    window.runningTests = true;
+    var tags = document.getElementsByTagName('script');
+    for (var i = tags.length; i >= 0; i--){
+      if (tags[i] && tags[i].getAttribute('src') != null && tags[i].getAttribute('src').indexOf(appName) !== -1) {
+        tags[i].parentNode.removeChild(tags[i]);
+      }
+    }
+    var script = document.createElement('script');
+    script.onload = function() {
+      setTimeout(function() {
+        window.runningTests = false;
+        window.devtools.service('hot-reload').trigger('newChanges', path);
+      }, 10);
+    };
+    script.type = 'text/javascript';
+    script.src = '/assets/' + appName + '.js';
+    document.body.appendChild(script);
+  };
+})();

--- a/tests/unit/instance-initializers/hot-loader-livereload-plugin-test.js
+++ b/tests/unit/instance-initializers/hot-loader-livereload-plugin-test.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import { initialize } from 'dummy/instance-initializers/hot-loader-livereload-plugin';
+import { module, test } from 'qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('Unit | Instance Initializer | hot loader livereload plugin', {
+  beforeEach: function() {
+    Ember.run(() => {
+      this.application = Ember.Application.create();
+      this.appInstance = this.application.buildInstance();
+    });
+  },
+  afterEach: function() {
+    Ember.run(this.appInstance, 'destroy');
+    destroyApp(this.application);
+  }
+});
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  initialize(this.appInstance);
+
+  // you would normally confirm the results of the initializer here
+  assert.ok(true);
+});


### PR DESCRIPTION
The functionality is the same, but avoid the need to tweak `node_modules/ember-cli/node_modules/tiny-lr/node_modules/livereload-js/dist/livereload.js`. 

It also moves the inline JS to its own file to make it easier to maintain. 
