### PR TITLE
Adds travis badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/toranb/ember-cli-hot-loader.svg?branch=master)](https://travis-ci.org/toranb/ember-cli-hot-loader)
+
 # Ember-cli-hot-loader
 
 An early look at what hot reloading might look like in the ember ecosystem


### PR DESCRIPTION
Can you enable travis before merging this? 

Now that we're adding more tests I would like to make sure we have this setup and we keep and green master. 