### PR TITLE
Moves samples from ember-samples/hot-reloaded-app to the dummy app so…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    # For now it doesn't work in Glimmer 2. We'll try to fix before the release.
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -24,22 +24,19 @@ export default Resolver.extend(HotReloadMixin);
 ## How to use this addon
 
 ```
-note: this project has only been tested with ember 2.4+
+note: this project doesn't work yet with ember 2.9 (beta at the moment), but we'll try to fix it before the official release. 
 ```
 
-1) You must use the hbs function with layout in your components (hbs files are not supported at this time)
+After installing it, simply run `ember serve` as usual, any changes you do to supported types, will result in a hotreload (no brower refresh). 
+Any additional changes will result in a regular liveReload. 
 
-```js
-import Ember from 'ember';
-import hbs from 'htmlbars-inline-precompile';
+### Supported Types
 
-export default Ember.Component.extend({
-  layout: hbs`
-    <h1>hello world</h1>
-  `
-});
-```
+At the moment, we only hotreload on component and its templates. 
+[ember-cli-styles-reloader](https://www.npmjs.com/package/ember-cli-styles-reloader) will do the styles for you. For support for other 
+types you can follow https://github.com/toranb/ember-cli-hot-loader/issues/6 
+or help us implement some of those. 
 
 ## Example application
 
-https://github.com/toranb/ember-redux-ddau-example/commit/81d5c4d254605dadf5dbf990138fb9f0a42b3a93
+To see this in action, you can clone this repo and run `ember serve`. 

--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import HotComponentMixin from 'ember-cli-hot-loader/mixins/hot-component';
 
-const { getOwner } = Ember;
+import clearCache from 'ember-cli-hot-loader/utils/clear-container-cache';
 
 export function matchesPodConvention (componentName, modulePath) {
   var filePathArray = modulePath.split('/');
@@ -24,25 +24,6 @@ function matchingComponent (componentName, modulePath) {
   // way to learn from resolver resolutions
   return matchesClassicConvention(componentName, modulePath) ||
     matchesPodConvention(componentName, modulePath);
-}
-
-function clearCache (context, componentName) {
-  const componentFullName = `component:${componentName}`;
-  const templateFullName = `template:components/${componentName}`;
-  const owner = getOwner(context);
-  function clear (name) {
-    owner.__container__.cache[name] = undefined;
-    owner.__container__.factoryCache[name] = undefined;
-    owner.__registry__._resolveCache[name] = undefined;
-    owner.__registry__._failCache[name] = undefined;
-
-    owner.base.__container__.cache[name] = undefined;
-    owner.base.__container__.factoryCache[name] = undefined;
-    owner.base.__registry__._resolveCache[name] = undefined;
-    owner.base.__registry__._failCache[name] = undefined;
-  }
-  clear(componentFullName);
-  clear(templateFullName);
 }
 
 const HotReplacementComponent = Ember.Component.extend(HotComponentMixin, {

--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -8,36 +8,41 @@ export function matchesPodConvention (componentName, modulePath) {
   var type = filePathArray[filePathArray.length - 3];
   var componentNameFromPath = filePathArray[filePathArray.length - 2];
   var fileName = filePathArray[filePathArray.length - 1];
-  return type === 'components' && componentName === componentNameFromPath && fileName === 'component.js';
+  return type === 'components' && componentName === componentNameFromPath && (fileName === 'component.js' || fileName === 'template.hbs');
 }
 export function matchesClassicConvention (componentName, modulePath) {
   var filePathArray = modulePath.split('/');
   var type = filePathArray[filePathArray.length - 2];
-  var componentNameFromPath = filePathArray[filePathArray.length - 1].replace(/.js$/, '');
+  var componentNameFromPath = filePathArray[filePathArray.length - 1].replace(/.js$|.hbs$/, '');
   return type === 'components' && componentName === componentNameFromPath;
 }
 function matchingComponent (componentName, modulePath) {
   if(!componentName) {
       return false;
   }
-  // For now we only support standard conventions, later we may have a better 
+  // For now we only support standard conventions, later we may have a better
   // way to learn from resolver resolutions
-  return matchesClassicConvention(componentName, modulePath) || 
+  return matchesClassicConvention(componentName, modulePath) ||
     matchesPodConvention(componentName, modulePath);
 }
 
 function clearCache (context, componentName) {
-  const name = `component:${componentName}`;
+  const componentFullName = `component:${componentName}`;
+  const templateFullName = `template:components/${componentName}`;
   const owner = getOwner(context);
-  owner.__container__.cache[name] = undefined;
-  owner.__container__.factoryCache[name] = undefined;
-  owner.__registry__._resolveCache[name] = undefined;
-  owner.__registry__._failCache[name] = undefined;
+  function clear (name) {
+    owner.__container__.cache[name] = undefined;
+    owner.__container__.factoryCache[name] = undefined;
+    owner.__registry__._resolveCache[name] = undefined;
+    owner.__registry__._failCache[name] = undefined;
 
-  owner.base.__container__.cache[name] = undefined;
-  owner.base.__container__.factoryCache[name] = undefined;
-  owner.base.__registry__._resolveCache[name] = undefined;
-  owner.base.__registry__._failCache[name] = undefined;
+    owner.base.__container__.cache[name] = undefined;
+    owner.base.__container__.factoryCache[name] = undefined;
+    owner.base.__registry__._resolveCache[name] = undefined;
+    owner.base.__registry__._failCache[name] = undefined;
+  }
+  clear(componentFullName);
+  clear(templateFullName);
 }
 
 const HotReplacementComponent = Ember.Component.extend(HotComponentMixin, {

--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -72,6 +72,11 @@ const HotReplacementComponent = Ember.Component.extend(HotComponentMixin, {
     `);
   }).volatile(),
 
+  __willLiveReload (event) {
+    if (matchingComponent(this.get('baseComponentName'), event.modulePath)) {
+      event.cancel = true;
+    }
+  },
   __rerenderOnTemplateUpdate (modulePath) {
       const baseComponentName = this.get('baseComponentName');
       const wrappedComponentName = this.get('wrappedComponentName');

--- a/addon/instance-initializers/hot-loader-livereload-plugin.js
+++ b/addon/instance-initializers/hot-loader-livereload-plugin.js
@@ -42,16 +42,31 @@ function createPlugin (appName, hotReloadService) {
   return Plugin;
 }
 
+function lookup (appInstance, fullName) {
+  if (appInstance.lookup) {
+    return appInstance.lookup(fullName);
+  }
+  return appInstance.application.__container__.lookup(fullName);
+}
+
+function getAppName (appInstance) {
+  if (appInstance.base) {
+    return appInstance.base.name;
+  }
+  // TODO: would this work in 2.4+?
+  return appInstance.application.name;
+}
+
 export function initialize(appInstance) {
   if (!window.LiveReload) {
     return;
   }
-  let appName = appInstance.base.name;
+  let appName = getAppName(appInstance);
   if (appName === 'ember-cli-hot-loader') {
     // TODO: find a better way to support other addons using the dummy app
     appName = 'dummy';
   }
-  const Plugin = createPlugin(appName, appInstance.lookup('service:hot-reload'));
+  const Plugin = createPlugin(appName, lookup(appInstance, 'service:hot-reload'));
   window.LiveReload.addPlugin(Plugin);
 }
 

--- a/addon/instance-initializers/hot-loader-livereload-plugin.js
+++ b/addon/instance-initializers/hot-loader-livereload-plugin.js
@@ -41,7 +41,12 @@ export function initialize(appInstance) {
   if (!window.LiveReload) {
     return;
   }
-  const Plugin = createPlugin(appInstance.base.name, appInstance.lookup('service:hot-reload'));
+  let appName = appInstance.base.name;
+  if (appName === 'ember-cli-hot-loader') {
+    // TODO: find a better way to support other addons using the dummy app
+    appName = 'dummy';
+  }
+  const Plugin = createPlugin(appName, appInstance.lookup('service:hot-reload'));
   window.LiveReload.addPlugin(Plugin);
 }
 

--- a/addon/instance-initializers/hot-loader-livereload-plugin.js
+++ b/addon/instance-initializers/hot-loader-livereload-plugin.js
@@ -23,7 +23,7 @@ function createPlugin (appName, hotReloadService) {
       script.onload = function() {
         setTimeout(function() {
           window.runningTests = false;
-          hotReloadService.trigger('newChanges', path);
+          hotReloadService.trigger('willHotReload', path);
         }, 10);
       };
       script.type = 'text/javascript';

--- a/addon/instance-initializers/hot-loader-livereload-plugin.js
+++ b/addon/instance-initializers/hot-loader-livereload-plugin.js
@@ -10,7 +10,8 @@ function createPlugin (appName, hotReloadService) {
     const cancelableEvent = { modulePath: path, cancel: false};
     hotReloadService.trigger('willLiveReload', cancelableEvent);
     if (cancelableEvent.cancel) {   // Only hotreload if someone canceled the regular reload
-      // TODO: is this needed? Consider removing since it might have undersired effects
+      // Reloading app.js will fire Application.create unless we set this.
+      // TODO: make sure this doesn't break tests
       window.runningTests = true;
       var tags = document.getElementsByTagName('script');
       for (var i = tags.length; i >= 0; i--){

--- a/addon/instance-initializers/hot-loader-livereload-plugin.js
+++ b/addon/instance-initializers/hot-loader-livereload-plugin.js
@@ -7,26 +7,31 @@ function createPlugin (appName, hotReloadService) {
   Plugin.identifier = 'ember-hot-reload';
   Plugin.version = '1.0'; // Just following the example, this might not be even used
   Plugin.prototype.reload = function(path) {
-        // TODO: is this needed? Consider removing since it might have undersired effects
-    window.runningTests = true;
-    var tags = document.getElementsByTagName('script');
-    for (var i = tags.length; i >= 0; i--){
-      if (tags[i] && tags[i].getAttribute('src') != null && tags[i].getAttribute('src').indexOf(appName) !== -1) {
-        tags[i].parentNode.removeChild(tags[i]);
+    const cancelableEvent = { modulePath: path, cancel: false};
+    hotReloadService.trigger('willLiveReload', cancelableEvent);
+    if (cancelableEvent.cancel) {   // Only hotreload if someone canceled the regular reload
+      // TODO: is this needed? Consider removing since it might have undersired effects
+      window.runningTests = true;
+      var tags = document.getElementsByTagName('script');
+      for (var i = tags.length; i >= 0; i--){
+        if (tags[i] && tags[i].getAttribute('src') != null && tags[i].getAttribute('src').indexOf(appName) !== -1) {
+          tags[i].parentNode.removeChild(tags[i]);
+        }
       }
-    }
-    var script = document.createElement('script');
-    script.onload = function() {
-      setTimeout(function() {
-        window.runningTests = false;
-        hotReloadService.trigger('newChanges', path);
-      }, 10);
-    };
-    script.type = 'text/javascript';
-    script.src = `/assets/${appName}.js`;
-    document.body.appendChild(script);
+      var script = document.createElement('script');
+      script.onload = function() {
+        setTimeout(function() {
+          window.runningTests = false;
+          hotReloadService.trigger('newChanges', path);
+        }, 10);
+      };
+      script.type = 'text/javascript';
+      script.src = `/assets/${appName}.js`;
+      document.body.appendChild(script);
 
-    return true;
+      return true;
+    }
+    return false;
   };
   Plugin.prototype.analyze = function() {
     return {

--- a/addon/mixins/hot-component.js
+++ b/addon/mixins/hot-component.js
@@ -4,12 +4,12 @@ export default Ember.Mixin.create({
   hotReload: Ember.inject.service(),
   init () {
     this._super(...arguments);
-    this.get('hotReload').on('newChanges', this, '__rerenderOnTemplateUpdate');
+    this.get('hotReload').on('willHotReload', this, '__rerenderOnTemplateUpdate');
     this.get('hotReload').on('willLiveReload', this, '__willLiveReload');
   },
   willDestroyElement () {
     this._super(...arguments);
-    this.get('hotReload').off('newChanges', this, '__rerenderOnTemplateUpdate');
+    this.get('hotReload').off('willHotReload', this, '__rerenderOnTemplateUpdate');
     this.get('hotReload').off('willLiveReload', this, '__willLiveReload');
   },
   __rerenderOnTemplateUpdate (/*moduleName*/) {

--- a/addon/mixins/hot-component.js
+++ b/addon/mixins/hot-component.js
@@ -5,10 +5,12 @@ export default Ember.Mixin.create({
   init () {
     this._super(...arguments);
     this.get('hotReload').on('newChanges', this, '__rerenderOnTemplateUpdate');
+    this.get('hotReload').on('willLiveReload', this, '__willLiveReload');
   },
   willDestroyElement () {
     this._super(...arguments);
     this.get('hotReload').off('newChanges', this, '__rerenderOnTemplateUpdate');
+    this.get('hotReload').off('willLiveReload', this, '__willLiveReload');
   },
   __rerenderOnTemplateUpdate (/*moduleName*/) {
     // abstract, to be overridden by mixee

--- a/addon/mixins/hot-reload-resolver.js
+++ b/addon/mixins/hot-reload-resolver.js
@@ -1,24 +1,52 @@
 import Ember from 'ember';
 import HotReplacementComponent from 'ember-cli-hot-loader/components/hot-replacement-component';
 
+function removeOriginalFromParsedName (parsedName) {
+  parsedName.fullName = parsedName.fullName.replace(/-original$/, '');
+  parsedName.fullNameWithoutType = parsedName.fullNameWithoutType.replace(/-original$/, '');
+  parsedName.name= parsedName.name.replace(/-original$/, '');
+}
+
+function shouldIgnoreTemplate (parsedName) {
+  return parsedName.fullName.match(/template:components\//) && !parsedName.fullName.match(/\-original$/);
+}
+
 export default Ember.Mixin.create({
   resolveOther (parsedName) {
+    if (parsedName.type === 'template' && shouldIgnoreTemplate(parsedName)) {
+      return;
+    }
+
     const resolved = this._super(...arguments);
     if (parsedName.type === 'component') {
       if (resolved) {
         return this._resolveComponent(resolved, parsedName);
       }
+      if (this._resolveOriginalTemplateForComponent(parsedName)) {
+        return this._resolveComponent(Ember.Component.extend(), parsedName);
+      }
       if (parsedName.fullName.match(/\-original$/)) {
-        parsedName.fullName = parsedName.fullName.replace(/-original$/, '');
-        parsedName.fullNameWithoutType = parsedName.fullNameWithoutType.replace(/-original$/, '');
-        parsedName.name= parsedName.name.replace(/-original$/, '');
+        removeOriginalFromParsedName(parsedName);
         return this._super(parsedName);
       }
     }
+
     return resolved;
   },
+  resolveTemplate (parsedName) {
+    if (shouldIgnoreTemplate(parsedName)) {
+      return;
+    }
 
+    removeOriginalFromParsedName(parsedName);
+    return this._super(...arguments);
+  },
   _resolveComponent (resolved, parsedName) {
     return HotReplacementComponent.createClass(resolved, parsedName);
+  },
+  _resolveOriginalTemplateForComponent (parsedName) {
+    const templateFullName = `template:components/${parsedName.fullNameWithoutType}-original`;
+    const templateParsedName = this.parseName(templateFullName);
+    return this.resolveTemplate(templateParsedName) || this.resolveOther(templateParsedName);
   }
 });

--- a/addon/services/hot-reload.js
+++ b/addon/services/hot-reload.js
@@ -1,9 +1,62 @@
 import Ember from 'ember';
 
-export default Ember.Service.extend(Ember.Evented, {
-  init () {
-    //TODO: non global alternatives please :)
-    window.hotReloadService = this;
-    this._super(...arguments);
-  }
-});
+/**
+  The `willLiveReload` event is fired when we have any JS or HBS changes
+  detected by Ember CLI. This gives you an opportunity to cancel the
+  regular liveReload in case we need .
+
+  The event fires 10ms *after* liveReload, if you want to prevent
+  liveReloading, you need to handle the cancelable event `willLiveReload`.
+
+  ```javascript
+  Ember.Something.extend({
+    hotReload: Ember.inject.service(),
+    init () {
+      this.get('hotReload').on('willLiveReload', (event)=>{
+        if (event.modulePath.match('foo')) {
+          event.cancel = true;
+        }
+      })
+    }
+  });
+  ```
+
+  @event willLiveReload
+  @param {Object} [event] A cancelable event with the modulePath
+    modulePath: {String}
+    cancel: {Boolean} indicates if we should cancel liveReloading
+  @public
+*/
+
+/**
+  The `newChanges` event is fired when we have any JS or HBS changes
+  detected by Ember CLI. This gives you an opportunity to handle
+  the event.
+
+  The event fires 10ms *after* liveReload, if you want to prevent
+  liveReloading, you need to handle the cancelable event `willLiveReload`.
+
+  ```javascript
+  Ember.Component.extend({
+    hotReload: Ember.inject.service(),
+    init () {
+      this.get('hotReload').on('newChanges', (modulePath)=>{
+        if (modulePath.match('foo')) {
+          window.alert('bar');
+        }
+      })
+    },
+
+    willDestroy () {
+      this.get('hotReload').off('newChanges');
+    }
+  });
+  ```
+
+  @event newChanges
+  @param {String} modulePath
+  @public
+*/
+
+
+export default Ember.Service.extend(Ember.Evented);

--- a/addon/services/hot-reload.js
+++ b/addon/services/hot-reload.js
@@ -29,7 +29,7 @@ import Ember from 'ember';
 */
 
 /**
-  The `newChanges` event is fired when we have any JS or HBS changes
+  The `willHotReload` event is fired when we have any JS or HBS changes
   detected by Ember CLI. This gives you an opportunity to handle
   the event.
 
@@ -40,7 +40,7 @@ import Ember from 'ember';
   Ember.Component.extend({
     hotReload: Ember.inject.service(),
     init () {
-      this.get('hotReload').on('newChanges', (modulePath)=>{
+      this.get('hotReload').on('willHotReload', (modulePath)=>{
         if (modulePath.match('foo')) {
           window.alert('bar');
         }
@@ -48,12 +48,12 @@ import Ember from 'ember';
     },
 
     willDestroy () {
-      this.get('hotReload').off('newChanges');
+      this.get('hotReload').off('willHotReload');
     }
   });
   ```
 
-  @event newChanges
+  @event willHotReload
   @param {String} modulePath
   @public
 */

--- a/addon/utils/clear-container-cache.js
+++ b/addon/utils/clear-container-cache.js
@@ -1,27 +1,33 @@
 import getOwner from 'ember-getowner-polyfill';
 
+function clearIfHasProperty (obj, propertyName) {
+  if (Object.hasOwnProperty.call(obj, propertyName)) {
+    obj[name] = undefined;
+  }
+}
+
 function clear (context, owner, name) {
   if (owner.__container__) {
-    owner.__container__.cache[name] = undefined;
-    owner.__container__.factoryCache[name] = undefined;
-    owner.__registry__._resolveCache[name] = undefined;
-    owner.__registry__._failCache[name] = undefined;
+    clearIfHasProperty(owner.__container__.cache, name);
+    clearIfHasProperty(owner.__container__.factoryCache, name);
+    clearIfHasProperty(owner.__registry__._resolveCache, name);
+    clearIfHasProperty(owner.__registry__._failCache, name);
 
-    owner.base.__container__.cache[name] = undefined;
-    owner.base.__container__.factoryCache[name] = undefined;
-    owner.base.__registry__._resolveCache[name] = undefined;
-    owner.base.__registry__._failCache[name] = undefined;
+    clearIfHasProperty(owner.base.__container__.cache, name);
+    clearIfHasProperty(owner.base.__container__.factoryCache, name);
+    clearIfHasProperty(owner.base.__registry__._resolveCache, name);
+    clearIfHasProperty(owner.base.__registry__._failCache, name);
   } else {
-    context.container.cache[name] = undefined;
-    context.container.factoryCache[name] = undefined;
-    context.container._registry._resolveCache[name] = undefined;
-    context.container._registry._failCache[name] = undefined;
+    clearIfHasProperty(context.container.cache, name);
+    clearIfHasProperty(context.container.factoryCache, name);
+    clearIfHasProperty(context.container._registry._resolveCache, name);
+    clearIfHasProperty(context.container._registry._failCache, name);
     // NOTE: the app's __container__ is the same as context.container. Not needed:
-    // window.Dummy.__container__.cache[name] = undefined;
-    // window.Dummy.__container__.factoryCache[name] = undefined;
+    // clearIfHasProperty(window.Dummy.__container__.cache, name);
+    // clearIfHasProperty(window.Dummy.__container__.factoryCache, name);
     // NOTE: the app's registry, is different than container._registry. We may need this
-    // window.Dummy.registry._resolveCache[name] = undefined;
-    // window.Dummy.registry._failCache[name] = undefined;
+    // clearIfHasProperty(window.Dummy.registry._resolveCache, name);
+    // clearIfHasProperty(window.Dummy.registry._failCache, name);
   }
 }
 

--- a/addon/utils/clear-container-cache.js
+++ b/addon/utils/clear-container-cache.js
@@ -1,0 +1,35 @@
+import getOwner from 'ember-getowner-polyfill';
+
+function clear (context, owner, name) {
+  if (owner.__container__) {
+    owner.__container__.cache[name] = undefined;
+    owner.__container__.factoryCache[name] = undefined;
+    owner.__registry__._resolveCache[name] = undefined;
+    owner.__registry__._failCache[name] = undefined;
+
+    owner.base.__container__.cache[name] = undefined;
+    owner.base.__container__.factoryCache[name] = undefined;
+    owner.base.__registry__._resolveCache[name] = undefined;
+    owner.base.__registry__._failCache[name] = undefined;
+  } else {
+    context.container.cache[name] = undefined;
+    context.container.factoryCache[name] = undefined;
+    context.container._registry._resolveCache[name] = undefined;
+    context.container._registry._failCache[name] = undefined;
+    // NOTE: the app's __container__ is the same as context.container. Not needed:
+    // window.Dummy.__container__.cache[name] = undefined;
+    // window.Dummy.__container__.factoryCache[name] = undefined;
+    // NOTE: the app's registry, is different than container._registry. We may need this
+    // window.Dummy.registry._resolveCache[name] = undefined;
+    // window.Dummy.registry._failCache[name] = undefined;
+  }
+}
+
+export default function clearContainerCache(context, componentName) {
+  const componentFullName = `component:${componentName}`;
+  const templateFullName = `template:components/${componentName}`;
+  const owner = getOwner(context);
+
+  clear(context, owner, componentFullName);
+  clear(context, owner, templateFullName);
+}

--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var path = require('path');
-var reloadExtensions = ['js'];
+var reloadExtensions = ['js', 'hbs'];
 var reloadJsPattern = new RegExp('\.(' + reloadExtensions.join('|') + ')$');
 
 var noop = function(){};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-data": "^2.7.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.7.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-getowner-polyfill": "1.0.1",

--- a/tests/dummy/app/components/inline-template-classic.js
+++ b/tests/dummy/app/components/inline-template-classic.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+export default Ember.Component.extend({
+  layout: hbs`
+    <p>From inline template classic. prop: {{prop1}}</p>
+  `,
+  prop1: 42
+});

--- a/tests/dummy/app/components/inline-template-pod/component.js
+++ b/tests/dummy/app/components/inline-template-pod/component.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+export default Ember.Component.extend({
+  layout: hbs`
+    <p>From inline template pod. prop: {{prop1}}</p>
+  `,
+  prop1: 1
+});

--- a/tests/dummy/app/components/js-only-classic.js
+++ b/tests/dummy/app/components/js-only-classic.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['js-only-classic1'],
+});

--- a/tests/dummy/app/components/js-only-pod/component.js
+++ b/tests/dummy/app/components/js-only-pod/component.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['js-only-pod2'],
+});

--- a/tests/dummy/app/components/mixed-classic.js
+++ b/tests/dummy/app/components/mixed-classic.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  // layout,  // The layout comes from the resoler as classic components do
+  prop1: 101
+});

--- a/tests/dummy/app/components/mixed-pod/component.js
+++ b/tests/dummy/app/components/mixed-pod/component.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  prop1: 202
+});

--- a/tests/dummy/app/components/mixed-pod/template.hbs
+++ b/tests/dummy/app/components/mixed-pod/template.hbs
@@ -1,0 +1,1 @@
+<p>From mixed-pod's template.  prop: {{prop1}}</p>

--- a/tests/dummy/app/components/template-only-pod/template.hbs
+++ b/tests/dummy/app/components/template-only-pod/template.hbs
@@ -1,0 +1,1 @@
+<p>From template-only-pod's template1.</p>

--- a/tests/dummy/app/resolver.js
+++ b/tests/dummy/app/resolver.js
@@ -1,3 +1,4 @@
 import Resolver from 'ember-resolver';
+import HotReloadMixin from 'ember-cli-hot-loader/mixins/hot-reload-resolver';
 
-export default Resolver;
+export default Resolver.extend(HotReloadMixin);

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,11 @@
+.js-only-classic1, .js-only-pod1 {
+  background: yellow;
+  width: 10px;
+  height: 10px;
+}
+
+.js-only-classic2, .js-only-pod2 {
+  background: red;
+  width: 10px;
+  height: 10px;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,0 +1,18 @@
+<h2>Template</h2>
+From app template: hi
+<h2>mixed-classic</h2>
+{{mixed-classic}}
+<h2>mixed-pod</h2>
+{{mixed-pod}}
+<h2>inline-template-classic</h2>
+{{inline-template-classic}}
+<h2>inline-template-pod</h2>
+{{inline-template-pod}}
+<h2>js-only-classic</h2>
+JS Only classic: {{js-only-classic}}
+<h2>js-only-pod</h2>
+{{js-only-pod}}
+<h2>template-only-classic</h2>
+{{template-only-classic}}
+<h2>template-only-pod</h2>
+{{template-only-pod}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -11,7 +11,7 @@ From app template: hi
 <h2>js-only-classic</h2>
 JS Only classic: {{js-only-classic}}
 <h2>js-only-pod</h2>
-{{js-only-pod}}
+JS Only pod: {{js-only-pod}}
 <h2>template-only-classic</h2>
 {{template-only-classic}}
 <h2>template-only-pod</h2>

--- a/tests/dummy/app/templates/components/mixed-classic.hbs
+++ b/tests/dummy/app/templates/components/mixed-classic.hbs
@@ -1,0 +1,1 @@
+<p>From mixed-classic's template. prop: {{prop1}}</p>

--- a/tests/dummy/app/templates/components/template-only-classic.hbs
+++ b/tests/dummy/app/templates/components/template-only-classic.hbs
@@ -1,0 +1,1 @@
+<p>From template-only-classic's template3.</p>

--- a/tests/unit/components/hot-replacement-component-test.js
+++ b/tests/unit/components/hot-replacement-component-test.js
@@ -11,15 +11,16 @@ module('Unit | Component | hot replacement component', {
 test('matchesPodConvention', function (assert) {
   // TODO: add support for addons
   assert.ok(matchesPodConvention('my-component', 'disk/path/to/app/components/my-component/component.js'));
+  assert.ok(matchesPodConvention('template-only-pod', 'disk/path/to/app/components/template-only-pod/template.hbs'));
   assert.notOk(matchesPodConvention('different-component', 'disk/path/to/app/components/my-component/component.js'));
   assert.notOk(matchesPodConvention('my-component', 'disk/path/to/app/different-type/my-component/component.js'));
   assert.notOk(matchesPodConvention('my-component', 'disk/path/to/app/components/different-component/component.js'));
-  assert.notOk(matchesPodConvention('my-component', 'disk/path/to/app/components/my-component/template.hbs'));
 });
 
 test('matchesClassicConvention', function (assert) {
   // TODO: add support for addons
   assert.ok(matchesClassicConvention('my-classic-component', 'disk/path/to/app/components/my-classic-component.js'));
+  assert.ok(matchesClassicConvention('template-only-classic', 'disk/path/to/app/app/templates/components/template-only-classic.hbs'));
   assert.notOk(matchesClassicConvention('different-component', 'disk/path/to/app/components/my-classic-component.js'));
   assert.notOk(matchesClassicConvention('my-classic-component', 'disk/path/to/app/different-type/my-classic-component.js'));
   assert.notOk(matchesClassicConvention('my-classic-component', 'disk/path/to/app/components/different-component.js'));

--- a/tests/unit/utils/clear-container-cache-test.js
+++ b/tests/unit/utils/clear-container-cache-test.js
@@ -1,0 +1,12 @@
+import clearCache from 'ember-cli-hot-loader/utils/clear-container-cache';
+import moduleForAcceptance from 'dummy/tests/helpers/module-for-acceptance';
+import { test } from 'qunit';
+
+moduleForAcceptance('Acceptance | Utility | clear container cache');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  assert.expect(0);
+  // Just want to make sure this doesn\'t crash in the different versions of Ember
+   clearCache(this.application.__container__.lookup('component:inline-template-pod', 'inline-template-pod'));
+});


### PR DESCRIPTION
… it’s all better self-contained

All the following examples are in dummy and working: 

```
{{mixed-classic}}
{{mixed-pod}}
{{inline-template-classic}}
{{inline-template-pod}}
{{js-only-classic}}
{{js-only-pod}}
{{template-only-classic}}
{{template-only-pod}}
```

See: 

![livereload](https://cloud.githubusercontent.com/assets/47388/18810507/c30ea424-826e-11e6-8485-7dfcfc5f317c.gif)

