### PR TITLE
Removes hardcoded appName for ember-cli-hot-loader

### DIFF
--- a/addon/instance-initializers/hot-loader-livereload-plugin.js
+++ b/addon/instance-initializers/hot-loader-livereload-plugin.js
@@ -1,3 +1,5 @@
+/* globals require */
+
 function createPlugin (appName, hotReloadService) {
 
   function Plugin (window, host) {
@@ -51,10 +53,13 @@ function lookup (appInstance, fullName) {
 }
 
 function getAppName (appInstance) {
+  if (require._eak_seen['dummy/config/environment']) {
+    // if we have the dummy/config, we're running the dummy app and the main bundle is dummy.js
+    return 'dummy';
+  }
   if (appInstance.base) {
     return appInstance.base.name;
   }
-  // TODO: would this work in 2.4+?
   return appInstance.application.name;
 }
 
@@ -63,10 +68,7 @@ export function initialize(appInstance) {
     return;
   }
   let appName = getAppName(appInstance);
-  if (appName === 'ember-cli-hot-loader') {
-    // TODO: find a better way to support other addons using the dummy app
-    appName = 'dummy';
-  }
+
   const Plugin = createPlugin(appName, lookup(appInstance, 'service:hot-reload'));
   window.LiveReload.addPlugin(Plugin);
 }


### PR DESCRIPTION
Fixes #20

This makes other addons dummy components work, however, components defined on `addon/components` still won't be hot-reloaded. That is the most common case for addon components, so I'll probably wait to have that working or at least fall back to live-reload. 

The problem doing this for `addon/components` is that we have to reload vendor.js, which blows away a few things, including `_eak_seek`. I'm considering changing the build to funnel the component/addons to app.js or a different file, [this RFC](https://github.com/ember-cli/rfcs/pull/52) may help us do it in a more standard way. 

Pending items. 
- [ ] ~~Fix blueprint so it modifies the resolver in dummy instead of creating a new file.~ (no need to fix this since the AST approach moves away from using a resolver)~~
- [x] Fix it for  `tests/dummy/components`
- [ ] Fix it for  `addon/components`
