### PR TITLE
[DOCS]: updated readme to show 2.9.0 stable is compat w/ v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ export default Resolver.extend(HotReloadMixin);
 
 ## How to use this addon
 
-```
-note: this project doesn't work yet with ember 2.9 (beta at the moment), but we'll try to fix it before the official release. 
-```
-
 After installing it, simply run `ember serve` as usual, any changes you do to supported types, will result in a hotreload (no brower refresh). 
 Any additional changes will result in a regular liveReload. 
 


### PR DESCRIPTION
Updating the readme to reflect the fact that 2.9.0 stable seems compatible w/ v0.1.1