### PR TITLE
Clears Glimmer 2 cache when we need to hot reload

### DIFF
--- a/addon/utils/clear-container-cache.js
+++ b/addon/utils/clear-container-cache.js
@@ -7,6 +7,10 @@ function clearIfHasProperty (obj, propertyName) {
 }
 
 function clear (context, owner, name) {
+  var environment = owner.lookup('service:-glimmer-environment');
+  if (environment) { // Glimmer2
+    environment._definitionCache.store.clear();
+  }
   if (owner.__container__) {
     clearIfHasProperty(owner.__container__.cache, name);
     clearIfHasProperty(owner.__container__.factoryCache, name);


### PR DESCRIPTION
Fixes https://github.com/toranb/ember-cli-hot-loader/issues/18

I tried a couple of options: 

* Clear all the glimmer2 cache, but only when we hot-reload. This is the approach I settled on for the reasons outlined below. 
* Setting the cache limit to 1 as suggested on https://github.com/toranb/ember-cli-hot-loader/issues/18#issuecomment-260765727. I'm afraid that may have some negative impacts for regular app rendering and we would have to handle cases where hotreloading is on/off, so I wanted to do something more specific. 
* I tried clearing only the cache for the component we're about to hot reload, just like we do pre-glimmer2, but the keys in the object are a compound of the `emberId|component-name` like `ember143|inline-template-classic`. I don't have an easy way to get the emberId, once we find out a reliable way to get it, we should probably move to this approach. 

I'll test this out today on some of our apps, but at least in the dummy app it works great and it maintains backwards compatibility