### PR TITLE
Support when positionalParams is a string

### DIFF
--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -26,29 +26,36 @@ function matchingComponent (componentName, modulePath) {
     matchesPodConvention(componentName, modulePath);
 }
 
+function getPositionalParamsArray (constructor) {
+  const positionalParams = constructor.positionalParams;
+  return typeof(positionalParams) === 'string' ?
+    [positionalParams] :
+    positionalParams;
+}
+
 const HotReplacementComponent = Ember.Component.extend(HotComponentMixin, {
   parsedName: null,
   tagName: '',
   layout: Ember.computed(function () {
-    const positionalParams = this.constructor.positionalParams;
+    let positionalParams = getPositionalParamsArray(this.constructor).join('');
     const attributesMap = Object.keys(this.attrs)
       .filter(key => positionalParams.indexOf(key) === -1)
       .map(key =>`${key}=${key}`).join(' ');
     return Ember.HTMLBars.compile(`
       {{#if hasBlock}}
         {{#if (hasBlock "inverse")}}
-          {{#component wrappedComponentName ${positionalParams.join(' ')} ${attributesMap} as |a b c d e f g h i j k|}}
+          {{#component wrappedComponentName ${positionalParams} ${attributesMap} as |a b c d e f g h i j k|}}
             {{yield a b c d e f g h i j k}}
           {{else}}
             {{yield to="inverse"}}
           {{/component}}
         {{else}}
-          {{#component wrappedComponentName ${positionalParams.join(' ')} ${attributesMap} as |a b c d e f g h i j k|}}
+          {{#component wrappedComponentName ${positionalParams} ${attributesMap} as |a b c d e f g h i j k|}}
             {{yield a b c d e f g h i j k}}
           {{/component}}
         {{/if}}
       {{else}}
-        {{component wrappedComponentName ${positionalParams.join(' ')} ${attributesMap}}}
+        {{component wrappedComponentName ${positionalParams} ${attributesMap}}}
       {{/if}}
     `);
   }).volatile(),

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -1,0 +1,13 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | application');
+
+test('visits dummy page and renders all wrapped components', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    // This verifies that at least the dummy page can be rendered
+    assert.equal(currentURL(), '/');
+  });
+});

--- a/tests/dummy/app/components/component-with-positionalparam-as-string.js
+++ b/tests/dummy/app/components/component-with-positionalparam-as-string.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+const Component = Ember.Component.extend({
+  // layout,  // The layout comes from the resoler as classic components do
+  param1: 'default value',
+  layout: hbs`
+    <p>prop from positional param: {{param1}}</p>
+  `,
+});
+
+Component.reopenClass({
+  positionalParams: 'param1'
+});
+
+export default Component;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -16,3 +16,5 @@ JS Only pod: {{js-only-pod}}
 {{template-only-classic}}
 <h2>template-only-pod</h2>
 {{template-only-pod}}
+<h2>component-with-positionalparam-as-string</h2>
+{{component-with-positionalparam-as-string "paramPassedFromApplicationTemplate"}}


### PR DESCRIPTION
This is valid according to http://emberjs.com/api/classes/Ember.Component.html#property_positionalParams previously we assumed it was always an array, but it can be a string, like https://github.com/martndemus/ember-font-awesome/blob/master/addon/components/fa-icon.js#L101

Fixes https://github.com/toranb/ember-cli-hot-loader/issues/30