### PR TITLE
[BUILD]: removed ember beta from the acceptable build failures list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    # For now it doesn't work in Glimmer 2. We'll try to fix before the release.
-    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/tests/unit/utils/clear-container-cache-test.js
+++ b/tests/unit/utils/clear-container-cache-test.js
@@ -7,6 +7,11 @@ moduleForAcceptance('Acceptance | Utility | clear container cache');
 // Replace this with your real tests.
 test('it works', function(assert) {
   assert.expect(0);
-  // Just want to make sure this doesn\'t crash in the different versions of Ember
-   clearCache(this.application.__container__.lookup('component:inline-template-pod', 'inline-template-pod'));
+  let done = assert.async();
+  visit('/');
+  andThen(() => {
+    // Just want to make sure this doesn\'t crash in the different versions of Ember
+    clearCache(this.application.__container__.lookup('component:inline-template-pod', 'inline-template-pod'));
+    done();
+  });
 });


### PR DESCRIPTION
Now that we are glimmer 2 friendly - removing the ember beta as acceptable failure