### PR TITLE
Clear requirejs cache on reload to work with Ember 2.11

### DIFF
--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import HotComponentMixin from 'ember-cli-hot-loader/mixins/hot-component';
 
 import clearCache from 'ember-cli-hot-loader/utils/clear-container-cache';
+import clearRequirejs from 'ember-cli-hot-loader/utils/clear-requirejs';
 
 export function matchesPodConvention (componentName, modulePath) {
   var filePathArray = modulePath.split('/');
@@ -61,8 +62,10 @@ const HotReplacementComponent = Ember.Component.extend(HotComponentMixin, {
   }).volatile(),
 
   __willLiveReload (event) {
-    if (matchingComponent(this.get('baseComponentName'), event.modulePath)) {
+    const baseComponentName = this.get('baseComponentName');
+    if (matchingComponent(baseComponentName, event.modulePath)) {
       event.cancel = true;
+      clearRequirejs(baseComponentName);
     }
   },
   __rerenderOnTemplateUpdate (modulePath) {

--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -65,7 +65,7 @@ const HotReplacementComponent = Ember.Component.extend(HotComponentMixin, {
     const baseComponentName = this.get('baseComponentName');
     if (matchingComponent(baseComponentName, event.modulePath)) {
       event.cancel = true;
-      clearRequirejs(baseComponentName);
+      clearRequirejs(this, baseComponentName);
     }
   },
   __rerenderOnTemplateUpdate (modulePath) {

--- a/addon/utils/clear-requirejs.js
+++ b/addon/utils/clear-requirejs.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 
 const { getOwner, get } = Ember;
 
+// Access requirejs global
+const requirejs = window.requirejs;
+
 /**
  * Unsee a requirejs module if it exists
  * @param {String} module The requirejs module name

--- a/addon/utils/clear-requirejs.js
+++ b/addon/utils/clear-requirejs.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+
+const { getOwner, get } = Ember;
+
+/**
+ * Unsee a requirejs module if it exists
+ * @param {String} module The requirejs module name
+ */
+function requireUnsee(module) {
+  if (requirejs.has(module)) {
+    requirejs.unsee(module);
+  }
+}
+
+export default function clearContainerCache(context, componentName) {
+  const owner = getOwner(context);
+  const config = owner.resolveRegistration('config:environment');
+  const appName = get(owner, 'base.name') || get(owner, 'application.name');
+  const modulePrefix = get(config, 'modulePrefix') || appName;
+  const podModulePrefix = get(config, 'podModulePrefix');
+
+  // Invalidate regular module
+  requireUnsee(`${modulePrefix}/components/${componentName}`);
+  requireUnsee(`${modulePrefix}/templates/components/${componentName}`);
+
+  // Invalidate pod modules
+  requireUnsee(`${podModulePrefix}/components/${componentName}/component`);
+  requireUnsee(`${podModulePrefix}/components/${componentName}/template`);
+}

--- a/index.js
+++ b/index.js
@@ -23,10 +23,10 @@ module.exports = {
         // Require template compiler as in CLI this is only used in build, we need it at runtime
         if (fs.existsSync(bowerPath)) {
             app.import(bowerPath);
-        }
-
-        if (fs.existsSync(npmPath)) {
+        } else if (fs.existsSync(npmPath)) {
             app.import(npmPath);
+        } else {
+            throw new Error('Unable to locate ember-template-compiler.js. ember/ember-source not found in either bower_components or node_modules');
         }
     }
 };

--- a/index.js
+++ b/index.js
@@ -4,12 +4,29 @@
 module.exports = {
     name: 'ember-cli-hot-loader',
     serverMiddleware: function (config){
-        var lsReloader = require('./lib/hot-reloader')(config.options);
-        lsReloader.run();
+        if (config.options.environment === 'development') {
+            var lsReloader = require('./lib/hot-reloader')(config.options);
+            lsReloader.run();
+        }
     },
     included: function (app) {
         this._super.included(app);
-        // TODO: consider removing this since it adds an unnecessary runtime dependency to all apps
-        app.import(app.bowerDirectory + '/ember/ember-template-compiler.js');
+
+        // If not in dev, bail
+        if (app.env !== 'development') {
+            return;
+        }
+
+        const bowerPath = app.bowerDirectory + '/ember/ember-template-compiler.js';
+        const npmPath = app.project.nodeModulesPath + '/ember-source/dist/ember-template-compiler.js';
+
+        // Require template compiler as in CLI this is only used in build, we need it at runtime
+        if (fs.existsSync(bowerPath)) {
+            app.import(bowerPath);
+        }
+
+        if (fs.existsSync(npmPath)) {
+            app.import(npmPath);
+        }
     }
 };

--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ module.exports = {
             return;
         }
 
-        const bowerPath = app.bowerDirectory + '/ember/ember-template-compiler.js';
-        const npmPath = app.project.nodeModulesPath + '/ember-source/dist/ember-template-compiler.js';
+        var bowerPath = app.bowerDirectory + '/ember/ember-template-compiler.js';
+        var npmPath = app.project.nodeModulesPath + '/ember-source/dist/ember-template-compiler.js';
 
         // Require template compiler as in CLI this is only used in build, we need it at runtime
         if (fs.existsSync(bowerPath)) {

--- a/index.js
+++ b/index.js
@@ -4,16 +4,19 @@
 module.exports = {
     name: 'ember-cli-hot-loader',
     serverMiddleware: function (config){
-        if (config.options.environment === 'development') {
-            var lsReloader = require('./lib/hot-reloader')(config.options);
-            lsReloader.run();
+        // If in production, don't add reloader
+        if (config.options.environment === 'production') {
+            return;
         }
+
+        var lsReloader = require('./lib/hot-reloader')(config.options);
+        lsReloader.run();
     },
     included: function (app) {
         this._super.included(app);
 
-        // If not in dev, bail
-        if (app.env !== 'development') {
+        // If in production, don't add ember-template-compiler
+        if (app.env === 'production') {
             return;
         }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 /* jshint node: true */
 'use strict';
+var fs = require('fs');
 
 module.exports = {
     name: 'ember-cli-hot-loader',


### PR DESCRIPTION
# What
It appears that there have been API changes with 2.11 and the addon no loner works. I've debugged this down to requirejs caching modules and so when the new `app.js` is injected into the dom, it doesn't refresh existing modules. This is simply fixed by `unseeing` the module in requirejs.

Additionally, if not using bower (per 2.11 dropping bower as the default for ember.js source), the addon produces an error as it tries to include the bower file. Also throw an exception if file not found.

# Test
Install with ember 2.11. Reloading should work for regular & pod components.