### PR TITLE
Default `podModulePrefix` to `modulePrefix` if not set

### DIFF
--- a/addon/utils/clear-requirejs.js
+++ b/addon/utils/clear-requirejs.js
@@ -2,25 +2,26 @@ import Ember from 'ember';
 
 const { getOwner, get } = Ember;
 
-// Access requirejs global
-const requirejs = window.requirejs;
-
 /**
  * Unsee a requirejs module if it exists
  * @param {String} module The requirejs module name
  */
 function requireUnsee(module) {
-  if (requirejs.has(module)) {
-    requirejs.unsee(module);
+  if (window.requirejs.has(module)) {
+      window.requirejs.unsee(module);
   }
 }
 
-export default function clearContainerCache(context, componentName) {
-  const owner = getOwner(context);
-  const config = owner.resolveRegistration('config:environment');
-  const appName = get(owner, 'base.name') || get(owner, 'application.name');
-  const modulePrefix = get(config, 'modulePrefix') || appName;
-  const podModulePrefix = get(config, 'podModulePrefix');
+/**
+ * Clears the requirejs cache for a component, checking for both "classic"
+ * style components & "pod" style components
+ *
+ * @param {Object} config The applicaiton config
+ * @param {String} componentName The component name being reloaded
+ */
+export function clearRequirejsCache(config, componentName) {
+  const modulePrefix = get(config, 'modulePrefix');
+  const podModulePrefix = get(config, 'podModulePrefix') || modulePrefix;
 
   // Invalidate regular module
   requireUnsee(`${modulePrefix}/components/${componentName}`);
@@ -29,4 +30,17 @@ export default function clearContainerCache(context, componentName) {
   // Invalidate pod modules
   requireUnsee(`${podModulePrefix}/components/${componentName}/component`);
   requireUnsee(`${podModulePrefix}/components/${componentName}/template`);
+}
+
+/**
+ * Clears the requirejs cache for a component, checking for both "classic"
+ * style components & "pod" style components
+ *
+ * @param {Object} component The component that's being reloaded
+ * @param {String} componentName The component name being reloaded
+ */
+export default function (component, componentName) {
+  const owner = getOwner(component);
+  const config = owner.resolveRegistration('config:environment');
+  clearRequirejsCache(config, componentName);
 }

--- a/app/utils/clear-requirejs.js
+++ b/app/utils/clear-requirejs.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-hot-loader/utils/clear-requirejs';

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "0.6.0",
+    "ember-sinon-qunit": "1.4.1",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/tests/unit/utils/clear-requirejs-test.js
+++ b/tests/unit/utils/clear-requirejs-test.js
@@ -1,0 +1,56 @@
+import {clearRequirejsCache} from 'ember-cli-hot-loader/utils/clear-requirejs';
+import {module} from 'qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+
+module('Unit | Utility | clear requirejs');
+
+// Ensure modulePrefix is used to construct the correct path
+test('it works with modulePrefix', function () {
+  const mock = this.mock(window.requirejs);
+  mock.expects("has").once().withExactArgs('foo/components/bar').returns(true);
+  mock.expects("has").once().withExactArgs('foo/templates/components/bar').returns(true);
+  mock.expects("has").once().withExactArgs('foo/components/bar/component').returns(true);
+  mock.expects("has").once().withExactArgs('foo/components/bar/template').returns(true);
+
+  mock.expects("unsee").once().withExactArgs('foo/components/bar');
+  mock.expects("unsee").once().withExactArgs('foo/templates/components/bar');
+  mock.expects("unsee").once().withExactArgs('foo/components/bar/component');
+  mock.expects("unsee").once().withExactArgs('foo/components/bar/template');
+
+  clearRequirejsCache({modulePrefix: 'foo'}, 'bar');
+
+  mock.verify();
+});
+
+// Ensure if podModulePrefix exists, it is used to construct the correct path for pod modules
+test('it works with podModulePrefix', function () {
+  const mock = this.mock(window.requirejs);
+  mock.expects("has").once().withExactArgs('foo/components/bar').returns(true);
+  mock.expects("has").once().withExactArgs('foo/templates/components/bar').returns(true);
+  mock.expects("has").once().withExactArgs('foo/pods/components/bar/component').returns(true);
+  mock.expects("has").once().withExactArgs('foo/pods/components/bar/template').returns(true);
+
+  mock.expects("unsee").once().withExactArgs('foo/components/bar');
+  mock.expects("unsee").once().withExactArgs('foo/templates/components/bar');
+  mock.expects("unsee").once().withExactArgs('foo/pods/components/bar/component');
+  mock.expects("unsee").once().withExactArgs('foo/pods/components/bar/template');
+
+  clearRequirejsCache({modulePrefix: 'foo', podModulePrefix: 'foo/pods'}, 'bar');
+});
+
+// Ensure that if has() returns false, unsee() is not called
+test('it doesnt call unsee() if has() returns false', function () {
+  const mock = this.mock(window.requirejs);
+  mock.expects("has").once().withExactArgs('foo/components/bar').returns(true);
+  mock.expects("has").once().withExactArgs('foo/templates/components/bar').returns(false);
+  mock.expects("has").once().withExactArgs('foo/components/bar/component').returns(true);
+  mock.expects("has").once().withExactArgs('foo/components/bar/template').returns(false);
+
+  mock.expects("unsee").once().withExactArgs('foo/components/bar');
+  mock.expects("unsee").never().withExactArgs('foo/templates/components/bar');
+  mock.expects("unsee").once().withExactArgs('foo/components/bar/component');
+  mock.expects("unsee").never().withExactArgs('foo/components/bar/template');
+
+  clearRequirejsCache({modulePrefix: 'foo'}, 'bar');
+});
+


### PR DESCRIPTION
Hey guys

Found a bug in my code here. If you don't define a `podModulePrefix` in your environment, then it defaults to null, which causes the module path to be `/components/${componentName}/component`. This is incorrect. Without a `podModulePrefix` requirejs uses `${modulePrefix}/components/${componentName}/component`. 

Additionally, if `modulePrefix` is undefined, the app doesn't even boot, so I removed the `appName` default.

@toranb @MiguelMadero 