### PR TITLE
Updates travis and package.json to use node4 instead of 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "toranb/ember-cli-hot-loader",
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">= 4"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
This may be considered a breaking change, but since the current version is already broken due to broccoli-merge-tree I would prefer to release it directly to master and release as 0.1.x

Also, I would on a separate PR move us over to yarn to be better shielded from this types of issues and still have a nightly build that semver drifts. 