### PR TITLE
Handle nested components

### DIFF
--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -4,19 +4,39 @@ import HotComponentMixin from 'ember-cli-hot-loader/mixins/hot-component';
 import clearCache from 'ember-cli-hot-loader/utils/clear-container-cache';
 import clearRequirejs from 'ember-cli-hot-loader/utils/clear-requirejs';
 
+function regexEscape(s) {
+  return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
 export function matchesPodConvention (componentName, modulePath) {
-  var filePathArray = modulePath.split('/');
-  var type = filePathArray[filePathArray.length - 3];
-  var componentNameFromPath = filePathArray[filePathArray.length - 2];
-  var fileName = filePathArray[filePathArray.length - 1];
-  return type === 'components' && componentName === componentNameFromPath && (fileName === 'component.js' || fileName === 'template.hbs');
+  var basePath = 'components/' + componentName;
+  var componentRegexp = new RegExp(regexEscape(basePath + '/component.js') + '$');
+  if (componentRegexp.test(modulePath)) {
+    return true;
+  }
+
+  var templateRegex = new RegExp(regexEscape(basePath + '/template.hbs') + '$');
+  if (templateRegex.test(modulePath)) {
+    return true;
+  }
+
+  return false;
 }
+
 export function matchesClassicConvention (componentName, modulePath) {
-  var filePathArray = modulePath.split('/');
-  var type = filePathArray[filePathArray.length - 2];
-  var componentNameFromPath = filePathArray[filePathArray.length - 1].replace(/.js$|.hbs$/, '');
-  return type === 'components' && componentName === componentNameFromPath;
+  var componentRegexp = new RegExp(regexEscape('components/' + componentName + '.js') + '$');
+  if (componentRegexp.test(modulePath)) {
+    return true;
+  }
+
+  var templateRegexp = new RegExp(regexEscape('templates/components/' + componentName + '.hbs') + '$');
+  if (templateRegexp.test(modulePath)) {
+    return true;
+  }
+
+  return false;
 }
+
 function matchingComponent (componentName, modulePath) {
   if(!componentName) {
       return false;

--- a/tests/unit/components/hot-replacement-component-test.js
+++ b/tests/unit/components/hot-replacement-component-test.js
@@ -12,8 +12,11 @@ test('matchesPodConvention', function (assert) {
   // TODO: add support for addons
   assert.ok(matchesPodConvention('my-component', 'disk/path/to/app/components/my-component/component.js'));
   assert.ok(matchesPodConvention('template-only-pod', 'disk/path/to/app/components/template-only-pod/template.hbs'));
+  assert.ok(matchesPodConvention('my-component/sub-component', 'disk/path/to/app/components/my-component/sub-component/component.js'));
+  assert.ok(matchesPodConvention('my-component/sub-component', 'disk/path/to/app/components/my-component/sub-component/template.hbs'));
   assert.notOk(matchesPodConvention('different-component', 'disk/path/to/app/components/my-component/component.js'));
   assert.notOk(matchesPodConvention('my-component', 'disk/path/to/app/different-type/my-component/component.js'));
+  assert.notOk(matchesPodConvention('my-component', 'disk/path/to/app/components/different-component/component.js'));
   assert.notOk(matchesPodConvention('my-component', 'disk/path/to/app/components/different-component/component.js'));
 });
 
@@ -21,6 +24,8 @@ test('matchesClassicConvention', function (assert) {
   // TODO: add support for addons
   assert.ok(matchesClassicConvention('my-classic-component', 'disk/path/to/app/components/my-classic-component.js'));
   assert.ok(matchesClassicConvention('template-only-classic', 'disk/path/to/app/app/templates/components/template-only-classic.hbs'));
+  assert.ok(matchesClassicConvention('my-component/sub-component', 'disk/path/to/app/app/components/my-component/sub-component.js'));
+  assert.ok(matchesClassicConvention('my-component/sub-component', 'disk/path/to/app/app/templates/components/my-component/sub-component.hbs'));
   assert.notOk(matchesClassicConvention('different-component', 'disk/path/to/app/components/my-classic-component.js'));
   assert.notOk(matchesClassicConvention('my-classic-component', 'disk/path/to/app/different-type/my-classic-component.js'));
   assert.notOk(matchesClassicConvention('my-classic-component', 'disk/path/to/app/components/different-component.js'));

--- a/tests/unit/components/hot-replacement-component-test.js
+++ b/tests/unit/components/hot-replacement-component-test.js
@@ -14,6 +14,8 @@ test('matchesPodConvention', function (assert) {
   assert.ok(matchesPodConvention('template-only-pod', 'disk/path/to/app/components/template-only-pod/template.hbs'));
   assert.ok(matchesPodConvention('my-component/sub-component', 'disk/path/to/app/components/my-component/sub-component/component.js'));
   assert.ok(matchesPodConvention('my-component/sub-component', 'disk/path/to/app/components/my-component/sub-component/template.hbs'));
+  assert.ok(matchesPodConvention('my-component/sub-component/woofer-component', 'disk/path/to/app/components/my-component/sub-component/woofer-component/component.js'));
+  assert.ok(matchesPodConvention('my-component/sub-component/woofer-component', 'disk/path/to/app/components/my-component/sub-component/woofer-component/template.hbs'));
   assert.notOk(matchesPodConvention('different-component', 'disk/path/to/app/components/my-component/component.js'));
   assert.notOk(matchesPodConvention('my-component', 'disk/path/to/app/different-type/my-component/component.js'));
   assert.notOk(matchesPodConvention('my-component', 'disk/path/to/app/components/different-component/component.js'));
@@ -26,6 +28,8 @@ test('matchesClassicConvention', function (assert) {
   assert.ok(matchesClassicConvention('template-only-classic', 'disk/path/to/app/app/templates/components/template-only-classic.hbs'));
   assert.ok(matchesClassicConvention('my-component/sub-component', 'disk/path/to/app/app/components/my-component/sub-component.js'));
   assert.ok(matchesClassicConvention('my-component/sub-component', 'disk/path/to/app/app/templates/components/my-component/sub-component.hbs'));
+  assert.ok(matchesClassicConvention('my-component/sub-component/woofer-component', 'disk/path/to/app/app/components/my-component/sub-component/woofer-component.js'));
+  assert.ok(matchesClassicConvention('my-component/sub-component/woofer-component', 'disk/path/to/app/app/templates/components/my-component/sub-component/woofer-component.hbs'));
   assert.notOk(matchesClassicConvention('different-component', 'disk/path/to/app/components/my-classic-component.js'));
   assert.notOk(matchesClassicConvention('my-classic-component', 'disk/path/to/app/different-type/my-classic-component.js'));
   assert.notOk(matchesClassicConvention('my-classic-component', 'disk/path/to/app/components/different-component.js'));


### PR DESCRIPTION
# What
Currently nested components, like `foo/bar-baz` cause a live reload rather than a hot reload. This is due to the way we're matching against the module name https://github.com/toranb/ember-cli-hot-loader/blob/master/addon/components/hot-replacement-component.js#L9

This PR changes these methods to perform a regex rather than a string split. Given the module paths are deterministic, we know what the patterns are for pods and classic components.

# Test
Added tests for the sub-post syntax.

Let me know if this is the wrong direction, but it seems to work.