### PR TITLE
DEPENDENCY: Upgrade ember-getowner-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-getowner-polyfill": "^1.1.1"
+    "ember-getowner-polyfill": "^2.2.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,7 +1972,7 @@ ember-ajax@^3.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
-ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
+ember-cli-babel@^5.1.7:
   version "5.2.4"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -2168,7 +2168,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.7:
   version "1.3.1"
   resolved "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
@@ -2280,19 +2280,18 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-factory-for-polyfill@^1.1.0:
+ember-factory-for-polyfill@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
+  resolved "https://npm.global.square/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
   dependencies:
     ember-cli-version-checker "^2.1.0"
 
-ember-getowner-polyfill@^1.1.1:
-  version "1.2.5"
-  resolved "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.5.tgz#ceff8a09897d0d7e05c821bb71666a95eb26dc92"
+ember-getowner-polyfill@^2.2.0:
+  version "2.2.0"
+  resolved "https://npm.global.square/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
   dependencies:
-    ember-cli-babel "^5.1.6"
-    ember-cli-version-checker "^1.2.0"
-    ember-factory-for-polyfill "^1.1.0"
+    ember-cli-version-checker "^2.1.0"
+    ember-factory-for-polyfill "^1.3.1"
 
 ember-load-initializers@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Hi, I would like to upgrade this dependency. The older version causes a build issue for me in the host project I try to use the addon in (using Ember 2.15.0):

```
$ ember serve
Livereload server on http://localhost:7020
The Broccoli Plugin: [BroccoliMergeTrees: Addon#treeFor (ember-cli-hot-loader - addon)] failed with:
ReferenceError: [BABEL] ember-getowner-polyfill/index.js: Unknown option: PROJECT_DIR/.babelrc.presets
```

It seems babel 5 vs babel 6 related, but since upgrading this dependency fixes it, I did not want to spend time digging into root cause.

Let me know if this seems reasonable.