### PR TITLE
Break private resolver template cache (aka: ember v3.1.1 support)

### DIFF
--- a/addon/mixins/hot-reload-resolver.js
+++ b/addon/mixins/hot-reload-resolver.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import HotReplacementComponent from 'ember-cli-hot-loader/components/hot-replacement-component';
+import { captureTemplateOptions } from 'ember-cli-hot-loader/utils/clear-container-cache';
 
 function removeOriginalFromParsedName (parsedName) {
   parsedName.fullName = parsedName.fullName.replace(/-original$/, '');
@@ -13,6 +14,8 @@ function shouldIgnoreTemplate (parsedName) {
 
 export default Ember.Mixin.create({
   resolveOther (parsedName) {
+    captureTemplateOptions(parsedName);
+
     if (parsedName.type === 'template' && shouldIgnoreTemplate(parsedName)) {
       return;
     }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -30,7 +30,7 @@ module.exports = {
       name: 'ember-3.1',
       npm: {
         devDependencies: {
-          'ember-source': '~3.1.0'
+          'ember-source': '~3.1.1'
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-resolver": "^4.0.0",
     "ember-sinon": "0.6.0",
     "ember-sinon-qunit": "1.4.1",
-    "ember-source": "~3.1.0",
+    "ember-source": "~3.1.1",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
     "ember-source-channel-url": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,9 +2551,9 @@ ember-source-channel-url@^1.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.1.0.tgz#21902747801c747b615f60168712968db3b433fc"
+ember-source@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.1.1.tgz#9cf95e8a6d7568d60b8eda2aeda17ac8944e654b"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"


### PR DESCRIPTION
![screen shot 2018-04-26 at 9 37 24 pm](https://user-images.githubusercontent.com/147411/39341712-0d457830-499a-11e8-84db-4a6ae4865638.png)

https://github.com/emberjs/ember.js/pull/16558/files

^this private template resolver cache in ember v3.1.1 broke the hot reloader. I've worked around this by capturing the [private suffix](https://github.com/emberjs/ember.js/blob/e01bc8cf7918c0b4d15037aa9134cafd226823a6/packages/container/lib/registry.js#L735) and storing it in the clear cache utils so we can run this magic 1 liner

```js
runtimeResolver.componentDefinitionCache.clear();
```