### PR TITLE
Break private resolver template cache for ember v3.2

### DIFF
--- a/addon/utils/clear-container-cache.js
+++ b/addon/utils/clear-container-cache.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 const { getOwner } = Ember;
 
 var templateOptionsKey = null;
+var templateCompilerKey = null;
 
 function clearIfHasProperty (obj, propertyName) {
   if (obj && Object.hasOwnProperty.call(obj, propertyName)) {
@@ -17,9 +18,15 @@ function clear (context, owner, name) {
   }
   if (templateOptionsKey) { // Ember v3.1.1
     var templateOptions = owner.lookup(templateOptionsKey);
-    var compileTimeLookup = templateOptions.resolver;
-    var runtimeResolver = compileTimeLookup.resolver;
-    runtimeResolver.componentDefinitionCache.clear();
+    var optionsTimeLookup = templateOptions.resolver;
+    var optionsRuntimeResolver = optionsTimeLookup.resolver;
+    optionsRuntimeResolver.componentDefinitionCache.clear();
+  }
+  if (templateCompilerKey) { // Ember v3.2
+    var templateCompiler = owner.lookup(templateCompilerKey);
+    var compileTimeLookup = templateCompiler.resolver;
+    var compileRuntimeResolver = compileTimeLookup.resolver;
+    compileRuntimeResolver.componentDefinitionCache.clear();
   }
   if (owner.__container__) {
     clearIfHasProperty(owner.__container__.cache, name);
@@ -48,15 +55,20 @@ function clear (context, owner, name) {
   }
 }
 
-var regex = new RegExp('template-options:main-(.*)');
+var optionsRegex = new RegExp('template-options:main-(.*)');
+var compilerRegex = new RegExp('template-compiler:main-(.*)');
 export function captureTemplateOptions(parsedName) {
-  if (templateOptionsKey) {
+  if (templateCompilerKey || templateOptionsKey) {
     return;
   }
   var name = parsedName.fullName || '';
-  var matched = name.match(regex);
-  if (matched && matched.length > 0) {
+  var optionsMatch = name.match(optionsRegex);
+  if (optionsMatch && optionsMatch.length > 0) {
     templateOptionsKey = name;
+  }
+  var compilerMatch = name.match(compilerRegex);
+  if (compilerMatch && compilerMatch.length > 0) {
+    templateCompilerKey = name;
   }
 }
 


### PR DESCRIPTION
In the [beta](https://github.com/emberjs/ember.js/releases/tag/v3.2.0-beta.3) of ember v3.2 I found that the private resolver we clear in the v3.1.1 series was named differently. Instead of using `template-options:main` we need to capture `template-compiler:main` 

I'm starting to plan the v1.0 release and think that supporting v3.2+ will help baseline the project. As a result this delta between 3.1.1 and 3.2 will soon be a relic of the past :)

