### PR TITLE
CONFIGURATION: added support for custom file types to extend the hot reloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ An early look at what hot reloading might look like in the ember ecosystem
 ember install ember-cli-hot-loader
 ```
 
-During installation Ember CLI will prompt you to update the resolver code. This is required for ember-cli-hot-loader to work. 
-If you have never modified the resolver, you can simply accept the changes or do a diff and update it manually. 
+During installation Ember CLI will prompt you to update the resolver code. This is required for ember-cli-hot-loader to work.
+If you have never modified the resolver, you can simply accept the changes or do a diff and update it manually.
 The final code should look something like:
 
 ```js
@@ -23,16 +23,24 @@ export default Resolver.extend(HotReloadMixin);
 
 ## How to use this addon
 
-After installing it, simply run `ember serve` as usual, any changes you do to supported types, will result in a hotreload (no brower refresh). 
-Any additional changes will result in a regular liveReload. 
+After installing it, simply run `ember serve` as usual, any changes you do to supported types, will result in a hotreload (no brower refresh).
+Any additional changes will result in a regular liveReload.
 
-### Supported Types
+## Configurations and Supported Types
 
-At the moment, we only hotreload on component and its templates. 
-[ember-cli-styles-reloader](https://www.npmjs.com/package/ember-cli-styles-reloader) will do the styles for you. For support for other 
-types you can follow https://github.com/toranb/ember-cli-hot-loader/issues/6 
-or help us implement some of those. 
+* ember-cli will hot reload styles for you when using ember-cli 2.3+
+* ember-cli-hot-loader will hot reload component JS/HBS changes
+* to hot reload another file type, such as reducers you need to first enable it:
+
+```javascript
+//my-app/config/environment.js
+ENV['ember-cli-hot-loader'] = {
+  supportedTypes: ['components', 'reducers']
+}
+```
 
 ## Example application
 
-To see this in action, you can clone this repo and run `ember serve`. 
+An example application that hot reloads styles/components/reducers
+
+https://github.com/toranb/ember-hot-reload-demo

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var path = require('path');
 module.exports = {
   name: 'ember-cli-hot-loader',
   serverMiddleware: function (config){
-    if (config.options.environment !== 'development') {
+    if (config.options.environment === 'production') {
       return;
     }
 
@@ -16,7 +16,7 @@ module.exports = {
   included: function (app) {
     this._super.included(app);
 
-    if (app.env !== 'development') {
+    if (app.env === 'production') {
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -1,36 +1,36 @@
 /* eslint-env node */
 'use strict';
 var fs = require('fs');
+var path = require('path');
 
 module.exports = {
-    name: 'ember-cli-hot-loader',
-    serverMiddleware: function (config){
-        // If in production, don't add reloader
-        if (config.options.environment === 'production') {
-            return;
-        }
-
-        var lsReloader = require('./lib/hot-reloader')(config.options);
-        lsReloader.run();
-    },
-    included: function (app) {
-        this._super.included(app);
-
-        // If in production, don't add ember-template-compiler
-        if (app.env === 'production') {
-            return;
-        }
-
-        var bowerPath = app.bowerDirectory + '/ember/ember-template-compiler.js';
-        var npmPath = require.resolve('ember-source/dist/ember-template-compiler.js');
-
-        // Require template compiler as in CLI this is only used in build, we need it at runtime
-        if (fs.existsSync(bowerPath)) {
-            app.import(bowerPath);
-        } else if (fs.existsSync(npmPath)) {
-            app.import(npmPath);
-        } else {
-            throw new Error('Unable to locate ember-template-compiler.js. ember/ember-source not found in either bower_components or node_modules');
-        }
+  name: 'ember-cli-hot-loader',
+  serverMiddleware: function (config){
+    if (config.options.environment !== 'development') {
+      return;
     }
+
+    var lsReloader = require('./lib/hot-reloader')(config.options);
+    lsReloader.run();
+  },
+  included: function (app) {
+    this._super.included(app);
+
+    if (app.env !== 'development') {
+      return;
+    }
+
+    var bowerPath = path.join(app.bowerDirectory, 'ember', 'ember-template-compiler.js');
+    var npmCompilerPath = path.join('ember-source', 'dist', 'ember-template-compiler.js');
+    var npmPath = require.resolve(npmCompilerPath);
+
+    // Require template compiler as in CLI this is only used in build, we need it at runtime
+    if (fs.existsSync(bowerPath)) {
+      app.import(bowerPath);
+    } else if (fs.existsSync(npmPath)) {
+      app.import(npmPath);
+    } else {
+      throw new Error('Unable to locate ember-template-compiler.js. ember/ember-source not found in either bower_components or node_modules');
+    }
+  }
 };

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
       return;
     }
 
-    var lsReloader = require('./lib/hot-reloader')(config.options);
+    var lsReloader = require('./lib/hot-reloader')(config.options, this.supportedTypes);
     lsReloader.run();
   },
   included: function (app) {
@@ -19,6 +19,10 @@ module.exports = {
     if (app.env !== 'development') {
       return;
     }
+
+    var config = app.project.config('development');
+    var addonConfig = config[this.name] || { supportedTypes: ['components'] };
+    this.supportedTypes = addonConfig['supportedTypes'];
 
     var bowerPath = path.join(app.bowerDirectory, 'ember', 'ember-template-compiler.js');
     var npmCompilerPath = path.join('ember-source', 'dist', 'ember-template-compiler.js');

--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -10,16 +10,15 @@ var reloadJsPattern = new RegExp('\.(' + reloadExtensions.join('|') + ')$');
 
 var noop = function(){};
 
-module.exports = function StylesReloader(options){
+module.exports = function HotReloader(options, supportedTypes){
   var fsWatcher = options.watcher;
   var ui = options.ui;
   var _isRunning = false;
   var lsProxy = options.ssl ? require('https') : require('http');
 
-  // var appComponentsPath = path.join(options.project.root, 'app', 'components', '*');
-  // var appReducersPath = path.join(options.project.root, 'app', 'reducers', '*');
-  // var appJSPattern = new RegExp('\.(' + appComponentsPath + '|' appReducersPath + ')$');
-  var appJSPath = path.join(options.project.root, 'app', 'components', '*');
+  var appJSPath = supportedTypes.map(function(reloadType) {
+    return path.join(options.project.root, 'app', reloadType, '*');
+  }).join('||^');
   var appJSPattern = new RegExp('^' + appJSPath);
   var appJSResource = options.project.pkg.name + '.js';
 
@@ -50,11 +49,11 @@ module.exports = function StylesReloader(options){
       var url;
       ui.writeLine('Reloading ' + filePath + ' only');
       try {
-          url = liveReloadHostname + '/changed?files=' + filePath;
-          ui.writeLine('GET' + url);
-          lsProxy.get(url).on('error', noop);
+        url = liveReloadHostname + '/changed?files=' + filePath;
+        ui.writeLine('GET' + url);
+        lsProxy.get(url).on('error', noop);
       } catch(e) {
-          ui.writeLine('??what the fuu' + e);
+        ui.writeLine('unknown error hot reloading: ' + e);
       }
     }
   }


### PR DESCRIPTION
Previously we didn't offer an extension that allowed developers to extend what types were hot reload-able 

Going forward you can crack open the ENV config and add the types you want to hot reload like so

```javascript
//my-app/config/environment.js
ENV['ember-cli-hot-loader'] = {
  supportedTypes: ['components', 'reducers']
}
```
