### PR TITLE
ENV: only use the hot reloader when env === development

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,6 +7,10 @@ module.exports = function(defaults) {
     // Add options here
   });
 
+  if(app.env === 'test') {
+    app.import('node_modules/ember-source/dist/ember-template-compiler.js');
+  }
+
   /*
     This build file specifies the options for the dummy test app of this
     addon, located in `/tests/dummy`

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var path = require('path');
 module.exports = {
   name: 'ember-cli-hot-loader',
   serverMiddleware: function (config){
-    if (config.options.environment === 'production') {
+    if (config.options.environment !== 'development') {
       return;
     }
 
@@ -16,7 +16,7 @@ module.exports = {
   included: function (app) {
     this._super.included(app);
 
-    if (app.env === 'production') {
+    if (app.env !== 'development') {
       return;
     }
 


### PR DESCRIPTION
Previously the hot reloader would be active in both dev & test environments. This allows the developer to test drive like out of the box ember-cli w/ testem (live reload) but "hot reload" when in development mode.