### PR TITLE
support other dev environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var path = require('path');
 module.exports = {
   name: 'ember-cli-hot-loader',
   serverMiddleware: function (config){
-    if (app.env === 'production' || app.env === 'test') {
+    if (config.options.environment === 'production' || config.options.environment === 'test') {
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var path = require('path');
 module.exports = {
   name: 'ember-cli-hot-loader',
   serverMiddleware: function (config){
-    if (config.options.environment !== 'development') {
+    if (app.env === 'production' || app.env === 'test') {
       return;
     }
 
@@ -16,7 +16,7 @@ module.exports = {
   included: function (app) {
     this._super.included(app);
 
-    if (app.env !== 'development') {
+    if (app.env === 'production' || app.env === 'test') {
       return;
     }
 


### PR DESCRIPTION
Toran - Do you think this is too restrictive the other way?  This allows environments such as staging, etc.  Should we regex match instead with the word `development`?