### PR TITLE
TYPESCRIPT: better support typescript component files

### DIFF
--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -42,8 +42,9 @@ export function matchingComponent (componentName, modulePath) {
       return false;
   }
   var standardModulePath = modulePath.split('\\').join('/');
-  return matchesClassicConvention(componentName, standardModulePath) ||
-    matchesPodConvention(componentName, standardModulePath);
+  var javascriptPath = standardModulePath.replace(/\.ts$/, '.js');
+  return matchesClassicConvention(componentName, javascriptPath) ||
+    matchesPodConvention(componentName, javascriptPath);
 }
 
 function getPositionalParamsArray (constructor) {

--- a/lib/hot-reloader.js
+++ b/lib/hot-reloader.js
@@ -3,7 +3,7 @@
 'use strict';
 
 var path = require('path');
-var reloadExtensions = ['js', 'hbs'];
+var reloadExtensions = ['js', 'ts', 'hbs'];
 
 // eslint-disable-next-line
 var reloadJsPattern = new RegExp('\.(' + reloadExtensions.join('|') + ')$');

--- a/tests/unit/components/hot-replacement-component-test.js
+++ b/tests/unit/components/hot-replacement-component-test.js
@@ -13,6 +13,13 @@ test('matchingComponent for posix and windows modulePaths', function (assert) {
   assert.ok(matchingComponent('header-markup', '\\Users\\billut\\code\\rando\\todomvc\\app\\templates\\components\\header-markup.hbs'));
 });
 
+test('typescript matches found', function (assert) {
+  assert.ok(matchingComponent('my-component', 'disk/path/to/app/components/my-component/component.ts'));
+  assert.ok(matchingComponent('my-component/sub-component', 'disk/path/to/app/components/my-component/sub-component/component.ts'));
+  assert.ok(matchingComponent('my-classic-component', 'disk/path/to/app/components/my-classic-component.ts'));
+  assert.ok(matchingComponent('my-component/sub-component', 'disk/path/to/app/app/components/my-component/sub-component.ts'));
+});
+
 test('matchesPodConvention', function (assert) {
   // TODO: add support for addons
   assert.ok(matchesPodConvention('my-component', 'disk/path/to/app/components/my-component/component.js'));


### PR DESCRIPTION
Previously we didn't watch files w/ the `.ts` extension. This will add support for typescript component files