### PR TITLE
BUILD: swap the hot reload resolver mixin for prod/test to omit compo…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,9 @@ cache:
   yarn: true
 
 env:
-  - EMBER_TRY_SCENARIO=ember-lts-2.12
   - EMBER_TRY_SCENARIO=ember-lts-2.18
   - EMBER_TRY_SCENARIO=ember-3.1
-  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-3.2
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -13,14 +13,6 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-          }
-        },
-        {
           name: 'ember-lts-2.18',
           npm: {
             devDependencies: {
@@ -32,15 +24,15 @@ module.exports = function() {
           name: 'ember-3.1',
           npm: {
             devDependencies: {
-              'ember-source': '~3.1.1'
+              'ember-source': '~3.1.3'
             }
           }
         },
         {
-          name: 'ember-beta',
+          name: 'ember-3.2',
           npm: {
             devDependencies: {
-              'ember-source': urls[1]
+              'ember-source': '~3.2.2'
             }
           }
         }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
+var map = require('broccoli-stew').map;
 
 module.exports = {
   name: 'ember-cli-hot-loader',
@@ -36,5 +37,19 @@ module.exports = {
     } else {
       throw new Error('Unable to locate ember-template-compiler.js. ember/ember-source not found in either bower_components or node_modules');
     }
+  },
+
+  treeFor(name) {
+    if (this.app.env === 'production' || this.app.env === 'test') {
+      if (name === 'app' || name === 'addon') {
+        const noopResolverMixin = 'define(\'ember-cli-hot-loader/mixins/hot-reload-resolver\', [\'exports\'], function (exports) { \'use strict\'; Object.defineProperty(exports, "__esModule", { value: true }); exports.default = Ember.Mixin.create({}); });';
+        const resolverMixin = 'ember-cli-hot-loader/mixins/hot-reload-resolver.js';
+        return map(this._super.treeFor.apply(this, arguments), (content, path) => {
+          return path === resolverMixin ? noopResolverMixin : content;
+        });
+      }
+      return;
+    }
+    return this._super.treeFor.apply(this, arguments);
   }
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-getowner-polyfill": "^2.2.0"
+    "broccoli-stew": "^1.5.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,7 +1229,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.5.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
@@ -2192,19 +2192,6 @@ ember-export-application-global@^2.0.0:
   resolved "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
-
-ember-factory-for-polyfill@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-
-ember-getowner-polyfill@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-    ember-factory-for-polyfill "^1.3.1"
 
 ember-load-initializers@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Beyond file watching we want to be sure apps with prod/test env don't ship with a patched resolver because the hot reload resolver will wrap each application component in a proxy for hot reloading/dev purposes