### PR TITLE
Branches/update hot reload cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ import HotReloadMixin from 'ember-cli-hot-loader/mixins/hot-reload-resolver';
 export default Resolver.extend(HotReloadMixin);
 ```
 
+note: The HotReloadMixin is replaced with an empty Mixin for production/test builds
+
 ## How to use this addon
 
-After installing it, simply run `ember serve` as usual, any changes you do to supported types, will result in a hotreload (no brower refresh).
-Any additional changes will result in a regular liveReload.
+After the ember install simply run `ember serve` as you normally would. Any changes to component JS/HBS files will result in a hot reload (not a full page reload). If you alter a route, service, controller or controller template ember-cli will do a full page reload.
 
 
 ## Example application
@@ -42,8 +43,10 @@ https://github.com/toranb/ember-hot-reload-demo
 
 ```javascript
 //my-app/config/environment.js
-ENV['ember-cli-hot-loader'] = {
-  supportedTypes: ['components', 'reducers']
+if (environment === 'development') {
+  ENV['ember-cli-hot-loader'] = {
+    supportedTypes: ['components', 'reducers']
+  }
 }
 ```
 
@@ -75,6 +78,10 @@ export default Service.extend(Evented, {
 });
 ```
 
+## Community Plugins
+
+https://github.com/ember-redux/ember-redux-hot-loader
+
 ## Known Compatibility Workarounds
 
 #### Content Security Policy
@@ -84,8 +91,8 @@ There is a known issue when used in conjunction with [ember-cli-content-security
 When this plugin tries to execute the `Ember.HTMLBars.compile` function, a CSP (Content Security Policy) that does not allow `"unsafe-eval"` will block the JS execution with the following error:
 
 ```
-Uncaught EvalError: Refused to evaluate a string as JavaScript 
-because 'unsafe-eval' is not an allowed source of script in the 
+Uncaught EvalError: Refused to evaluate a string as JavaScript
+because 'unsafe-eval' is not an allowed source of script in the
 following Content Security Policy directive: "script-src ...
 ```
 
@@ -109,7 +116,3 @@ To workaround this issue, in the `config/environment.js` file, add `"unsafe-eval
     ENV.contentSecurityPolicy['script-src'].push("'unsafe-eval'");
   }
 ```
-
-## Community Plugins
-
-https://github.com/ember-redux/ember-redux-hot-loader

--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
+import { later } from '@ember/runloop';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 import HotComponentMixin from 'ember-cli-hot-loader/mixins/hot-component';
 
 import clearCache from 'ember-cli-hot-loader/utils/clear-container-cache';
@@ -54,10 +57,9 @@ function getPositionalParamsArray (constructor) {
     positionalParams;
 }
 
-const HotReplacementComponent = Ember.Component.extend(HotComponentMixin, {
+const HotReplacementComponent = Component.extend(HotComponentMixin, {
   parsedName: null,
-  tagName: '',
-  layout: Ember.computed(function () {
+  layout: computed(function () {
     let positionalParams = getPositionalParamsArray(this.constructor).join('');
     let attrs = this.attrs || {};
     const attributesMap = Object.keys(attrs)
@@ -66,18 +68,18 @@ const HotReplacementComponent = Ember.Component.extend(HotComponentMixin, {
     return Ember.HTMLBars.compile(`
       {{#if hasBlock}}
         {{#if (hasBlock "inverse")}}
-          {{#component wrappedComponentName ${positionalParams} ${attributesMap} targetObject=_targetObject as |a b c d e f g h i j k|}}
+          {{#component wrappedComponentName ${positionalParams} ${attributesMap} target=target as |a b c d e f g h i j k|}}
             {{yield a b c d e f g h i j k}}
           {{else}}
             {{yield to="inverse"}}
           {{/component}}
         {{else}}
-          {{#component wrappedComponentName ${positionalParams} ${attributesMap} targetObject=_targetObject as |a b c d e f g h i j k|}}
+          {{#component wrappedComponentName ${positionalParams} ${attributesMap} target=target as |a b c d e f g h i j k|}}
             {{yield a b c d e f g h i j k}}
           {{/component}}
         {{/if}}
       {{else}}
-        {{component wrappedComponentName ${positionalParams} ${attributesMap} targetObject=_targetObject}}
+        {{component wrappedComponentName ${positionalParams} ${attributesMap} target=target}}
       {{/if}}
     `);
   }).volatile(),
@@ -101,7 +103,7 @@ const HotReplacementComponent = Ember.Component.extend(HotComponentMixin, {
             baseComponentName: undefined
           });
           this.rerender();
-          Ember.run.later(()=> {
+          later(() => {
             this.setProperties({
               wrappedComponentName: wrappedComponentName,
               baseComponentName: baseComponentName

--- a/addon/instance-initializers/hot-loader-livereload-plugin.js
+++ b/addon/instance-initializers/hot-loader-livereload-plugin.js
@@ -13,7 +13,6 @@ function createPlugin (appName, hotReloadService, rootURL) {
     hotReloadService.trigger('willLiveReload', cancelableEvent);
     if (cancelableEvent.cancel) {   // Only hotreload if someone canceled the regular reload
       // Reloading app.js will fire Application.create unless we set this.
-      // TODO: make sure this doesn't break tests
       window.runningTests = true;
       var tags = document.getElementsByTagName('script');
       for (var i = tags.length; i >= 0; i--){

--- a/addon/mixins/hot-component.js
+++ b/addon/mixins/hot-component.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
+import Mixin from '@ember/object/mixin';
+import { inject as service } from '@ember/service';
 
-export default Ember.Mixin.create({
-  hotReload: Ember.inject.service(),
+export default Mixin.create({
+  hotReload: service(),
   init () {
     this._super(...arguments);
     this.get('hotReload').on('willHotReload', this, '__rerenderOnTemplateUpdate');

--- a/addon/mixins/hot-reload-resolver.js
+++ b/addon/mixins/hot-reload-resolver.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import Mixin from '@ember/object/mixin';
+import Component from '@ember/component';
 import HotReplacementComponent from 'ember-cli-hot-loader/components/hot-replacement-component';
 import { captureTemplateOptions } from 'ember-cli-hot-loader/utils/clear-container-cache';
 
@@ -12,7 +13,7 @@ function shouldIgnoreTemplate (parsedName) {
   return parsedName.fullName.match(/template:components\//) && !parsedName.fullName.match(/\-original$/); // eslint-disable-line
 }
 
-export default Ember.Mixin.create({
+export default Mixin.create({
   resolveOther (parsedName) {
     captureTemplateOptions(parsedName);
 
@@ -26,7 +27,7 @@ export default Ember.Mixin.create({
         return this._resolveComponent(resolved, parsedName);
       }
       if (this._resolveOriginalTemplateForComponent(parsedName)) {
-        return this._resolveComponent(Ember.Component.extend(), parsedName);
+        return this._resolveComponent(Component.extend(), parsedName);
       }
       if (parsedName.fullName.match(/\-original$/)) { // eslint-disable-line
         removeOriginalFromParsedName(parsedName);

--- a/addon/services/hot-reload.js
+++ b/addon/services/hot-reload.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import Service from '@ember/service';
+import Evented from '@ember/object/evented';
 
 /**
   The `willLiveReload` event is fired when we have any JS or HBS changes
@@ -10,7 +11,7 @@ import Ember from 'ember';
 
   ```javascript
   Ember.Something.extend({
-    hotReload: Ember.inject.service(),
+    hotReload: service(),
     init () {
       this.get('hotReload').on('willLiveReload', (event)=>{
         if (event.modulePath.match('foo')) {
@@ -37,8 +38,8 @@ import Ember from 'ember';
   liveReloading, you need to handle the cancelable event `willLiveReload`.
 
   ```javascript
-  Ember.Component.extend({
-    hotReload: Ember.inject.service(),
+  Component.extend({
+    hotReload: service(),
     init () {
       this.get('hotReload').on('willHotReload', (modulePath)=>{
         if (modulePath.match('foo')) {
@@ -59,4 +60,4 @@ import Ember from 'ember';
 */
 
 
-export default Ember.Service.extend(Ember.Evented);
+export default Service.extend(Evented);

--- a/addon/utils/clear-container-cache.js
+++ b/addon/utils/clear-container-cache.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { getOwner } = Ember;
+import { getOwner } from '@ember/application';
 
 var templateOptionsKey = null;
 var templateCompilerKey = null;
@@ -12,46 +10,28 @@ function clearIfHasProperty (obj, propertyName) {
 }
 
 function clear (context, owner, name) {
-  var environment = owner.lookup('service:-glimmer-environment');
-  if (environment) { // Glimmer2
-    environment._definitionCache && environment._definitionCache.store && environment._definitionCache.store.clear();
-  }
-  if (templateOptionsKey) { // Ember v3.1.1
-    var templateOptions = owner.lookup(templateOptionsKey);
-    var optionsTimeLookup = templateOptions.resolver;
-    var optionsRuntimeResolver = optionsTimeLookup.resolver;
-    optionsRuntimeResolver.componentDefinitionCache.clear();
-  }
   if (templateCompilerKey) { // Ember v3.2
     var templateCompiler = owner.lookup(templateCompilerKey);
     var compileTimeLookup = templateCompiler.resolver;
     var compileRuntimeResolver = compileTimeLookup.resolver;
     compileRuntimeResolver.componentDefinitionCache.clear();
+  } else if (templateOptionsKey) { // Ember v3.1.1
+    var templateOptions = owner.lookup(templateOptionsKey);
+    var optionsTimeLookup = templateOptions.resolver;
+    var optionsRuntimeResolver = optionsTimeLookup.resolver;
+    optionsRuntimeResolver.componentDefinitionCache.clear();
+  } else {
+    var environment = owner.lookup('service:-glimmer-environment');
+    if (environment) {
+      environment._definitionCache && environment._definitionCache.store && environment._definitionCache.store.clear();
+    }
   }
-  if (owner.__container__) {
-    clearIfHasProperty(owner.__container__.cache, name);
-    clearIfHasProperty(owner.__container__.factoryCache, name);
-    clearIfHasProperty(owner.__container__.factoryManagerCache, name);
-    clearIfHasProperty(owner.__registry__._resolveCache, name);
-    clearIfHasProperty(owner.__registry__._failCache, name);
 
+  if (owner.__container__) {
     clearIfHasProperty(owner.base.__container__.cache, name);
     clearIfHasProperty(owner.base.__container__.factoryCache, name);
     clearIfHasProperty(owner.base.__container__.factoryManagerCache, name);
     clearIfHasProperty(owner.base.__registry__._resolveCache, name);
-    clearIfHasProperty(owner.base.__registry__._failCache, name);
-  } else {
-    clearIfHasProperty(context.container.cache, name);
-    clearIfHasProperty(context.container.factoryCache, name);
-    clearIfHasProperty(context.container.factoryManagerCache, name);
-    clearIfHasProperty(context.container._registry._resolveCache, name);
-    clearIfHasProperty(context.container._registry._failCache, name);
-    // NOTE: the app's __container__ is the same as context.container. Not needed:
-    // clearIfHasProperty(window.Dummy.__container__.cache, name);
-    // clearIfHasProperty(window.Dummy.__container__.factoryCache, name);
-    // NOTE: the app's registry, is different than container._registry. We may need this
-    // clearIfHasProperty(window.Dummy.registry._resolveCache, name);
-    // clearIfHasProperty(window.Dummy.registry._failCache, name);
   }
 }
 

--- a/addon/utils/clear-requirejs.js
+++ b/addon/utils/clear-requirejs.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { getOwner, get } = Ember;
+import { get } from '@ember/object';
+import { getOwner } from '@ember/application';
 
 /**
  * Unsee a requirejs module if it exists

--- a/tests/unit/instance-initializers/hot-loader-livereload-plugin-test.js
+++ b/tests/unit/instance-initializers/hot-loader-livereload-plugin-test.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import Application from '@ember/application';
 import { initialize } from 'dummy/instance-initializers/hot-loader-livereload-plugin';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
 
 module('Unit | Instance Initializer | hot loader livereload plugin', {
   beforeEach: function() {
-    Ember.run(() => {
-      this.application = Ember.Application.create();
+    run(() => {
+      this.application = Application.create();
       this.appInstance = this.application.buildInstance();
     });
   },
   afterEach: function() {
-    Ember.run(this.appInstance, 'destroy');
+    run(this.appInstance, 'destroy');
     destroyApp(this.application);
   }
 });


### PR DESCRIPTION
Once merged this PR will mark the v1.0 of this prototype hot reloader. The breaking change included here is that instead of `tagName: ""` for the wrapper component as we did pre 1.0 ... this will have a default div. This solves #68 and shouldn't harm anything related to hot reloading specifically. It could alter the way an application looks visually so that's the reason we are doing a major bump :)

To remove the `targetObject` deprecation warning I've also dropped this in favor of `target` instead. This could mean that much older version of ember are no longer supported and if so the pre 1.0 version of this could live on for anyone who needs it. At some point I needed to make a clean break from the older `targetObject` else it would break for ember apps in the future :(

And finally, I've included a simplification/ reordering of the container cache break. I've test this w/ ember 2.18LTS, 3.0, 3.1.3, 3.2.2 and the latest 3.3 beta so I'm feeling good about the move. If anyone finds a problem with ember versions below 2.18LTS please let me know.