### PR TITLE
FEATURE: configuration to exclude components

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ note: The HotReloadMixin is replaced with an empty Mixin for production/test bui
 
 After the ember install simply run `ember serve` as you normally would. Any changes to component JS/HBS files will result in a hot reload (not a full page reload). If you alter a route, service, controller or controller template ember-cli will do a full page reload.
 
+## Excluding components
+
+If you want to exclude any component(s) from hot reloading simply configure them using `excluded`
+
+```javascript
+//my-app/config/environment.js
+if (environment === 'development') {
+  ENV['ember-cli-hot-loader'] = {
+    excluded: ['liquid-unless', 'liquid-child']
+  }
+}
+```
 
 ## Example application
 
@@ -35,7 +47,7 @@ An example application that hot reloads styles/components/reducers
 https://github.com/toranb/ember-hot-reload-demo
 
 
-## Configurations and Supported Types
+## Supported Types
 
 * ember-cli will hot reload styles for you when using ember-cli 2.3+
 * ember-cli-hot-loader will hot reload component JS/HBS changes

--- a/addon/mixins/hot-reload-resolver.js
+++ b/addon/mixins/hot-reload-resolver.js
@@ -1,6 +1,8 @@
 import Mixin from '@ember/object/mixin';
 import Component from '@ember/component';
 import HotReplacementComponent from 'ember-cli-hot-loader/components/hot-replacement-component';
+import { get, computed } from '@ember/object';
+import config from 'ember-get-config';
 import { captureTemplateOptions } from 'ember-cli-hot-loader/utils/clear-container-cache';
 
 function removeOriginalFromParsedName (parsedName) {
@@ -23,6 +25,10 @@ export default Mixin.create({
 
     const resolved = this._super(...arguments);
     if (parsedName.type === 'component') {
+      const excluded = get(this, 'excluded');
+      if (excluded.some((name) => name === parsedName.name)) {
+        return this._super(parsedName);
+      }
       if (resolved) {
         return this._resolveComponent(resolved, parsedName);
       }
@@ -52,5 +58,9 @@ export default Mixin.create({
     const templateFullName = `template:components/${parsedName.fullNameWithoutType}-original`;
     const templateParsedName = this.parseName(templateFullName);
     return this.resolveTemplate(templateParsedName) || this.resolveOther(templateParsedName);
-  }
+  },
+  excluded: computed(function() {
+    const exclude = config['ember-cli-hot-loader']['excluded'];
+    return exclude || [];
+  })
 });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
+    "ember-get-config": "^0.2.4",
     "broccoli-stew": "^1.5.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,6 +2193,13 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-get-config@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.3.0"
+
 ember-load-initializers@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-1.1.0.tgz#4edacc0f3a14d9f53d241ac3e5561804c8377978"


### PR DESCRIPTION
If you find a component that you prefer not be hot reload, or you bump into a less than supported addon you can simply omit those by adding the component name to this new configuration. Luke pointed me to a problem w/ liquid-child specifically so I felt this was a good workaround to unlock hot reloading for everything else ;)

```javascript
//my-app/config/environment.js
if (environment === 'development') {
  ENV['ember-cli-hot-loader'] = {
    excluded: ['liquid-unless', 'liquid-child']
  }
}
```
