### PR TITLE
Component rendering speed up (using cache for same templates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,29 +40,6 @@ if (environment === 'development') {
 }
 ```
 
-## Extended components exclusion
-
-If you want to get more control over any component(s) excluding from hot reloading you can implement custom logic in resolver mixin method, named `shouldExcludeComponent`.
-
-For example if we don't want to reload `ember-bootstrap` components -
-we need to exclude all components with names started with `bs-` prefix.
-
-```javascript
-import Resolver from 'ember-resolver';
-import HotReloadMixin from 'ember-cli-hot-loader/mixins/hot-reload-resolver';
-
-const CustomHotReloadMixin = HotReloadMixin.extend({
-  shouldExcludeComponent({name}) {
-    const excludedFromConfig = this._super(...arguments);
-    const isBootstrapComponent = name.startsWith('bs-');
-    return excludedFromConfig || isBootstrapComponent;
-  }
-});
-
-export default Resolver.extend(CustomHotReloadMixin);
-```
-
-
 ## Tagless wrapper component
 
 If you prefer to avoid the extra div that wraps each hot reloaded component configure it with tagless. Note: the tagless configuration does not support components that receive controller actions.

--- a/README.md
+++ b/README.md
@@ -47,14 +47,11 @@ If you want to get more control over any component(s) excluding from hot reloadi
 For example if we don't want to reload `ember-bootstrap` components -
 we need to exclude all components with names started with `bs-` prefix.
 
-Working example available at [lifeart/ember-hot-reload-demo](https://github.com/lifeart/ember-hot-reload-demo) (bs + non-reloadable `bs-button` component)
-
 ```javascript
 import Resolver from 'ember-resolver';
 import HotReloadMixin from 'ember-cli-hot-loader/mixins/hot-reload-resolver';
-import Mixin from '@ember/object/mixin';
 
-const CustomHotReloadMixin = Mixin.create(HotReloadMixin, {
+const CustomHotReloadMixin = HotReloadMixin.extend({
   shouldExcludeComponent({name}) {
     const excludedFromConfig = this._super(...arguments);
     const isBootstrapComponent = name.startsWith('bs-');

--- a/README.md
+++ b/README.md
@@ -40,6 +40,29 @@ if (environment === 'development') {
 }
 ```
 
+## Extended components exclusion
+
+If you want to get more control over any component(s) excluding from hot reloading you can implement custom logic in resolver mixin method, named `shouldExcludeComponent`.
+
+For example if we don't want to reload `ember-bootstrap` components -
+we need to exclude all components with names started with `bs-` prefix.
+
+```javascript
+import Resolver from 'ember-resolver';
+import HotReloadMixin from 'ember-cli-hot-loader/mixins/hot-reload-resolver';
+
+const CustomHotReloadMixin = HotReloadMixin.extend({
+  shouldExcludeComponent({name}) {
+    const excludedFromConfig = this._super(...arguments);
+    const isBootstrapComponent = name.startsWith('bs-');
+    return excludedFromConfig || isBootstrapComponent;
+  }
+});
+
+export default Resolver.extend(CustomHotReloadMixin);
+```
+
+
 ## Tagless wrapper component
 
 If you prefer to avoid the extra div that wraps each hot reloaded component configure it with tagless. Note: the tagless configuration does not support components that receive controller actions.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ If you want to get more control over any component(s) excluding from hot reloadi
 For example if we don't want to reload `ember-bootstrap` components -
 we need to exclude all components with names started with `bs-` prefix.
 
+Working example available at [lifeart/ember-hot-reload-demo](https://github.com/lifeart/ember-hot-reload-demo) (bs + non-reloadable `bs-button` component)
+
 ```javascript
 import Resolver from 'ember-resolver';
 import HotReloadMixin from 'ember-cli-hot-loader/mixins/hot-reload-resolver';
+import Mixin from '@ember/object/mixin';
 
-const CustomHotReloadMixin = HotReloadMixin.extend({
+const CustomHotReloadMixin = Mixin.create(HotReloadMixin, {
   shouldExcludeComponent({name}) {
     const excludedFromConfig = this._super(...arguments);
     const isBootstrapComponent = name.startsWith('bs-');

--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -12,7 +12,11 @@ function regexEscape(s) {
   return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'); // eslint-disable-line
 }
 
-let TemplatesCache = {};
+
+const TEMPLATE_CACHE_MAX_SIZE = 10000;
+const TEMPLATE_CACHE_GC_TIMEOUT = 1000;
+var TemplatesCache = {};
+var TemplateCacheCheckTimeout = null;
 
 function hashString(str) {
 
@@ -26,16 +30,17 @@ function hashString(str) {
         hash = hash & hash; // Convert to 32bit integer
     }
     return String(hash);
-    
+
 }
 
 function checkTemplatesCacheLimit() {
     // allow only 10k component templates in cache
-    setTimeout(()=>{
-        if (Object.keys(TemplatesCache).length > 10000) {
+    clearTimeout(TemplateCacheCheckTimeout);
+    TemplateCacheCheckTimeout = setTimeout(()=>{
+        if (Object.keys(TemplatesCache).length > TEMPLATE_CACHE_MAX_SIZE) {
             TemplatesCache = {};
         }
-    }, 1000);
+    }, TEMPLATE_CACHE_GC_TIMEOUT);
 }
 
 export function matchesPodConvention (componentName, modulePath) {

--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -16,12 +16,12 @@ let TemplatesCache = {};
 
 function hashString(str) {
 
-    var hash = 0;
+    let hash = 0;
     if (str.length == 0) {
         return hash;
     }
-    for (var i = 0; i < str.length; i++) {
-        var char = str.charCodeAt(i);
+    for (let i = 0; i < str.length; i++) {
+        let char = str.charCodeAt(i);
         hash = ((hash<<5)-hash)+char;
         hash = hash & hash; // Convert to 32bit integer
     }

--- a/addon/mixins/hot-reload-resolver.js
+++ b/addon/mixins/hot-reload-resolver.js
@@ -5,29 +5,45 @@ import { get, computed } from '@ember/object';
 import config from 'ember-get-config';
 import { captureTemplateOptions } from 'ember-cli-hot-loader/utils/clear-container-cache';
 
-function removeOriginalFromParsedName (parsedName) {
-  parsedName.fullName = parsedName.fullName.replace(/-original$/, '');
-  parsedName.fullNameWithoutType = parsedName.fullNameWithoutType.replace(/-original$/, '');
-  parsedName.name= parsedName.name.replace(/-original$/, '');
+const ORIGINAL_COMPONENT_POSTFIX = '-original';
+const TEMPLATE_MATCH_REGEX = new RegExp(/-original$/);
+
+function removeOriginalFromParsedName (parsedName, pattern) {
+  parsedName.fullName = parsedName.fullName.replace(pattern, '');
+  parsedName.fullNameWithoutType = parsedName.fullNameWithoutType.replace(pattern, '');
+  parsedName.name= parsedName.name.replace(pattern, '');
 }
 
-function shouldIgnoreTemplate (parsedName) {
-  return parsedName.fullName.match(/template:components\//) && !parsedName.fullName.match(/\-original$/); // eslint-disable-line
+function shouldIgnoreTemplate (parsedName, pattern) {
+  return parsedName.fullName.match(/template:components\//) && !parsedName.fullName.match(pattern); // eslint-disable-line
 }
 
 export default Mixin.create({
-  resolveOther (parsedName) {
+  originalTemplateMatchRegex: computed(function(){
+    return TEMPLATE_MATCH_REGEX;
+  }),
+  originalComponentPostfix: computed(function(){
+	return ORIGINAL_COMPONENT_POSTFIX;
+  }),
+  shouldExcludeComponent(parsedName) {
+	const excluded = get(this, 'excluded');
+	if (excluded.some((name) => name === parsedName.name)) {
+        return true;
+	} else {
+		return false;
+	}
+  },
+  resolveOther(parsedName) {
     captureTemplateOptions(parsedName);
-
-    if (parsedName.type === 'template' && shouldIgnoreTemplate(parsedName)) {
+    const templateMatchRegex = get(this, 'originalTemplateMatchRegex');
+    if (parsedName.type === 'template' && shouldIgnoreTemplate(parsedName, templateMatchRegex)) {
       return;
     }
 
     const resolved = this._super(...arguments);
     if (parsedName.type === 'component') {
-      const excluded = get(this, 'excluded');
-      if (excluded.some((name) => name === parsedName.name)) {
-        return this._super(parsedName);
+      if (this.shouldExcludeComponent(parsedName)) {
+		return this._super(parsedName);
       }
       if (resolved) {
         return this._resolveComponent(resolved, parsedName);
@@ -35,8 +51,8 @@ export default Mixin.create({
       if (this._resolveOriginalTemplateForComponent(parsedName)) {
         return this._resolveComponent(Component.extend(), parsedName);
       }
-      if (parsedName.fullName.match(/\-original$/)) { // eslint-disable-line
-        removeOriginalFromParsedName(parsedName);
+      if (parsedName.fullName.match(templateMatchRegex)) { // eslint-disable-line
+        removeOriginalFromParsedName(parsedName, templateMatchRegex);
         return this._super(parsedName);
       }
     }
@@ -44,18 +60,19 @@ export default Mixin.create({
     return resolved;
   },
   resolveTemplate (parsedName) {
-    if (shouldIgnoreTemplate(parsedName)) {
+    const templateMatchRegex = get(this, 'originalTemplateMatchRegex');
+    if (shouldIgnoreTemplate(parsedName, templateMatchRegex)) {
       return;
     }
 
-    removeOriginalFromParsedName(parsedName);
+    removeOriginalFromParsedName(parsedName, templateMatchRegex);
     return this._super(...arguments);
   },
   _resolveComponent (resolved, parsedName) {
     return HotReplacementComponent.createClass(resolved, parsedName);
   },
   _resolveOriginalTemplateForComponent (parsedName) {
-    const templateFullName = `template:components/${parsedName.fullNameWithoutType}-original`;
+    const templateFullName = `template:components/${parsedName.fullNameWithoutType}${this.originalComponentPostfix}`;
     const templateParsedName = this.parseName(templateFullName);
     return this.resolveTemplate(templateParsedName) || this.resolveOther(templateParsedName);
   },

--- a/addon/mixins/hot-reload-resolver.js
+++ b/addon/mixins/hot-reload-resolver.js
@@ -23,15 +23,15 @@ export default Mixin.create({
     return TEMPLATE_MATCH_REGEX;
   }),
   originalComponentPostfix: computed(function(){
-    return ORIGINAL_COMPONENT_POSTFIX;
+	return ORIGINAL_COMPONENT_POSTFIX;
   }),
   shouldExcludeComponent(parsedName) {
-    const excluded = get(this, 'excluded');
-    if (excluded.some((name) => name === parsedName.name)) {
-      return true;
-    } else {
-      return false;
-    }
+	const excluded = get(this, 'excluded');
+	if (excluded.some((name) => name === parsedName.name)) {
+        return true;
+	} else {
+		return false;
+	}
   },
   resolveOther(parsedName) {
     captureTemplateOptions(parsedName);
@@ -43,7 +43,7 @@ export default Mixin.create({
     const resolved = this._super(...arguments);
     if (parsedName.type === 'component') {
       if (this.shouldExcludeComponent(parsedName)) {
-        return this._super(parsedName);
+		return this._super(parsedName);
       }
       if (resolved) {
         return this._resolveComponent(resolved, parsedName);

--- a/addon/mixins/hot-reload-resolver.js
+++ b/addon/mixins/hot-reload-resolver.js
@@ -23,15 +23,15 @@ export default Mixin.create({
     return TEMPLATE_MATCH_REGEX;
   }),
   originalComponentPostfix: computed(function(){
-	return ORIGINAL_COMPONENT_POSTFIX;
+    return ORIGINAL_COMPONENT_POSTFIX;
   }),
   shouldExcludeComponent(parsedName) {
-	const excluded = get(this, 'excluded');
-	if (excluded.some((name) => name === parsedName.name)) {
-        return true;
-	} else {
-		return false;
-	}
+    const excluded = get(this, 'excluded');
+    if (excluded.some((name) => name === parsedName.name)) {
+      return true;
+    } else {
+      return false;
+    }
   },
   resolveOther(parsedName) {
     captureTemplateOptions(parsedName);
@@ -43,7 +43,7 @@ export default Mixin.create({
     const resolved = this._super(...arguments);
     if (parsedName.type === 'component') {
       if (this.shouldExcludeComponent(parsedName)) {
-		return this._super(parsedName);
+        return this._super(parsedName);
       }
       if (resolved) {
         return this._resolveComponent(resolved, parsedName);

--- a/index.js
+++ b/index.js
@@ -14,10 +14,6 @@ module.exports = {
     var lsReloader = require('./lib/hot-reloader')(config.options, this.supportedTypes);
     lsReloader.run();
   },
-  _getTemplateCompilerPath() {
-    var npmCompilerPath = path.join('ember-source', 'dist', 'ember-template-compiler.js');
-    return path.relative(this.project.root, require.resolve(npmCompilerPath));
-  },
   included: function (app) {
     this._super.included(app);
 
@@ -28,7 +24,9 @@ module.exports = {
     var config = app.project.config('development');
     var addonConfig = config[this.name] || { supportedTypes: ['components'] };
     this.supportedTypes = addonConfig['supportedTypes'] || ['components'];
-    var npmPath = addonConfig['templateCompilerPath'] || this._getTemplateCompilerPath();
+
+    var npmCompilerPath = path.join('ember-source', 'dist', 'ember-template-compiler.js');
+    var npmPath = path.relative(app.project.root, require.resolve(npmCompilerPath));
 
     // Require template compiler as in CLI this is only used in build, we need it at runtime
     if (fs.existsSync(npmPath)) {

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ module.exports = {
     var lsReloader = require('./lib/hot-reloader')(config.options, this.supportedTypes);
     lsReloader.run();
   },
+  _getTemplateCompilerPath() {
+    var npmCompilerPath = path.join('ember-source', 'dist', 'ember-template-compiler.js');
+    return path.relative(this.project.root, require.resolve(npmCompilerPath));
+  },
   included: function (app) {
     this._super.included(app);
 
@@ -24,9 +28,7 @@ module.exports = {
     var config = app.project.config('development');
     var addonConfig = config[this.name] || { supportedTypes: ['components'] };
     this.supportedTypes = addonConfig['supportedTypes'] || ['components'];
-
-    var npmCompilerPath = path.join('ember-source', 'dist', 'ember-template-compiler.js');
-    var npmPath = path.relative(app.project.root, require.resolve(npmCompilerPath));
+    var npmPath = addonConfig['templateCompilerPath'] || this._getTemplateCompilerPath();
 
     // Require template compiler as in CLI this is only used in build, we need it at runtime
     if (fs.existsSync(npmPath)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-hot-loader",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-hot-loader",
-  "version": "1.3.0",
+  "version": "1.2.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-hot-loader",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-hot-loader",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
I have alot of components on page > 300items.

And after `hot-loader` I see some rendering perf issues.
This pr solve rendering speed problem, providing caching for already compiled templates
At this moment cache size is 10k items, don't think we need more.

changes in `addon/components/hot-replacement-component.js`


results before:
![image](https://user-images.githubusercontent.com/1360552/45308781-f47eba80-b52a-11e8-8999-c4836188d26f.png)

results after: 

![image](https://user-images.githubusercontent.com/1360552/45308873-23952c00-b52b-11e8-804d-03211064a547.png)


Idea is:
Before calling `Ember.HTMLBars.compile` we calculate simple template string hash.
And if we have already compiled template for this hash, we reuse it, instead of compiling it one more time.