### PR TITLE
Component rendering speed up (using cache for same templates) (clean)

### DIFF
--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -13,12 +13,14 @@ function regexEscape(s) {
 }
 
 
-const TEMPLATE_CACHE_MAX_SIZE = 10000;
-const TEMPLATE_CACHE_GC_TIMEOUT = 1000;
-var TemplatesCache = {};
-var TemplateCacheCheckTimeout = null;
+export const TEMPLATE_CACHE_MAX_SIZE = 10000;
+export const TEMPLATE_CACHE_GC_TIMEOUT = 1000;
 
-function hashString(str) {
+export var TemplatesCache = {};
+export var TemplateCacheCheckTimeout = null;
+// this is fast-hashing function for string, taken from
+// https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
+export function hashString(str) {
 
     let hash = 0;
     if (str.length == 0) {
@@ -33,7 +35,8 @@ function hashString(str) {
 
 }
 
-function checkTemplatesCacheLimit() {
+// Object keys may be so expensive on large objects (on 10k, ~ 6ms), so it's kinda debounce logic
+export function checkTemplatesCacheLimit() {
     // allow only 10k component templates in cache
     clearTimeout(TemplateCacheCheckTimeout);
     TemplateCacheCheckTimeout = setTimeout(()=>{

--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -36,14 +36,14 @@ export function hashString(str) {
 }
 
 // Object keys may be so expensive on large objects (on 10k, ~ 6ms), so it's kinda debounce logic
-export function checkTemplatesCacheLimit() {
+export function checkTemplatesCacheLimit(timeout = TEMPLATE_CACHE_GC_TIMEOUT) {
     // allow only 10k component templates in cache
     clearTimeout(TemplateCacheCheckTimeout);
     TemplateCacheCheckTimeout = setTimeout(()=>{
         if (Object.keys(TemplatesCache).length > TEMPLATE_CACHE_MAX_SIZE) {
             TemplatesCache = {};
         }
-    }, TEMPLATE_CACHE_GC_TIMEOUT);
+    }, timeout);
 }
 
 export function matchesPodConvention (componentName, modulePath) {

--- a/tests/unit/components/hot-replacement-component-test.js
+++ b/tests/unit/components/hot-replacement-component-test.js
@@ -1,12 +1,16 @@
 import { module } from 'qunit';
 import { test } from 'ember-qunit';
-import { matchingComponent, matchesPodConvention, matchesClassicConvention } from 'ember-cli-hot-loader/components/hot-replacement-component';
-
+import { TEMPLATE_CACHE_MAX_SIZE, TEMPLATE_CACHE_GC_TIMEOUT, TemplatesCache, TemplateCacheCheckTimeout, checkTemplatesCacheLimit, hashString, matchingComponent, matchesPodConvention, matchesClassicConvention } from 'ember-cli-hot-loader/components/hot-replacement-component';
+import { Promise as EmberPromise } from 'rsvp';
 // NOTE: we test the functions of the class, not really the component
 // as a component, for that we'll write integration or acceptance tests
 module('Unit | Component | hot replacement component', {
   unit: true
 });
+
+function wait(ms) {
+    return new EmberPromise((resolve)=> setTimeout(resolve, ms));
+}
 
 test('matchingComponent for posix and windows modulePaths', function (assert) {
   assert.ok(matchingComponent('header-markup', '/Users/billut/code/rando/todomvc/app/templates/components/header-markup.hbs'));
@@ -46,4 +50,49 @@ test('matchesClassicConvention', function (assert) {
   assert.notOk(matchesClassicConvention('my-classic-component', 'disk/path/to/app/different-type/my-classic-component.js'));
   assert.notOk(matchesClassicConvention('my-classic-component', 'disk/path/to/app/components/different-component.js'));
   assert.notOk(matchesClassicConvention('my-classic-component', 'disk/path/to/app/components/my-classic-component.xx'));
+});
+
+test('canHashTemplteLayoutString', function (assert) {
+    assert.equal(typeof hashString('foo-bar'), 'string', 'result must be an numeric string');
+    assert.equal(hashString('foo-bar'), '-682120564');
+    assert.equal(hashString('bar-baz'), '-335205535');
+    assert.equal(hashString('{{some-component foo=bar}}'), '1904495296');
+    assert.equal(hashString('{{some-component foo=baz}}'), '1904502984');
+});
+
+test('templateHashesForSameStringsMustBeEqual', function (assert) {
+    assert.equal(hashString('foo-bar'), hashString('foo-bar'));
+    assert.equal(hashString('bar-baz'), hashString('bar-baz'));
+    assert.equal(hashString('{{some-component foo=bar}}'), hashString('{{some-component foo=bar}}'));
+    assert.equal(hashString('{{some-component foo=baz}}'), hashString('{{some-component foo=baz}}'));
+});
+
+test('checkTemplateHashLimitMustCreateTimeoutForCheckFunction', function (assert) {
+    const initialTimeoutCounterRef = TemplateCacheCheckTimeout;
+    checkTemplatesCacheLimit();
+    assert.notEqual(TemplateCacheCheckTimeout, initialTimeoutCounterRef);
+});
+
+test('templateCacheMustBeAnNonNullableObject', function (assert) {
+    assert.equal(typeof TemplatesCache, 'object');
+    assert.notEqual(TemplatesCache, null);
+});
+
+test('checkTemplatesCacheWipe', async function (assert) {
+    // lets wait for possible cache cleanup
+    await wait(TEMPLATE_CACHE_GC_TIMEOUT);
+    let cachedItems = Object.keys(TemplatesCache);
+    let itemsToAddToCache = TEMPLATE_CACHE_MAX_SIZE - cachedItems.length;
+    for (let i = 0; i < itemsToAddToCache; i++) {
+        TemplatesCache[`key-${Math.random().toString(36).slice(2)}`] = {};
+    }
+    assert.equal(Object.keys(TemplatesCache).length, TEMPLATE_CACHE_MAX_SIZE, 'cache is full');
+    checkTemplatesCacheLimit();
+    await wait(TEMPLATE_CACHE_GC_TIMEOUT);
+    assert.equal(Object.keys(TemplatesCache).length, TEMPLATE_CACHE_MAX_SIZE, 'cache is full, but not cleaned');
+    TemplatesCache[`key-foo-bar`] = {};
+    assert.notEqual(Object.keys(TemplatesCache).length, TEMPLATE_CACHE_MAX_SIZE, 'cache size if perfect to clean');
+    checkTemplatesCacheLimit();
+    await wait(TEMPLATE_CACHE_GC_TIMEOUT);
+    assert.equal(Object.keys(TemplatesCache).length, 0, 'cache cleaned');
 });

--- a/tests/unit/components/hot-replacement-component-test.js
+++ b/tests/unit/components/hot-replacement-component-test.js
@@ -82,8 +82,8 @@ test('checkTemplatesCacheWipe', async function (assert) {
     // lets escape from possible cache cleanup
 	clearTimeout(TemplateCacheCheckTimeout)
 	const cacheCheckerTimeout = 10;
-    let cachedItems = Object.keys(TemplatesCache);
-    let itemsToAddToCache = TEMPLATE_CACHE_MAX_SIZE - cachedItems.length;
+    const cachedItems = Object.keys(TemplatesCache);
+    const itemsToAddToCache = TEMPLATE_CACHE_MAX_SIZE - cachedItems.length;
     for (let i = 0; i < itemsToAddToCache; i++) {
         TemplatesCache[`key-${Math.random().toString(36).slice(2)}`] = {};
     }

--- a/tests/unit/components/hot-replacement-component-test.js
+++ b/tests/unit/components/hot-replacement-component-test.js
@@ -1,6 +1,6 @@
 import { module } from 'qunit';
 import { test } from 'ember-qunit';
-import { TEMPLATE_CACHE_MAX_SIZE, TEMPLATE_CACHE_GC_TIMEOUT, TemplatesCache, TemplateCacheCheckTimeout, checkTemplatesCacheLimit, hashString, matchingComponent, matchesPodConvention, matchesClassicConvention } from 'ember-cli-hot-loader/components/hot-replacement-component';
+import { TEMPLATE_CACHE_MAX_SIZE, TemplatesCache, TemplateCacheCheckTimeout, checkTemplatesCacheLimit, hashString, matchingComponent, matchesPodConvention, matchesClassicConvention } from 'ember-cli-hot-loader/components/hot-replacement-component';
 import { Promise as EmberPromise } from 'rsvp';
 // NOTE: we test the functions of the class, not really the component
 // as a component, for that we'll write integration or acceptance tests
@@ -79,20 +79,21 @@ test('templateCacheMustBeAnNonNullableObject', function (assert) {
 });
 
 test('checkTemplatesCacheWipe', async function (assert) {
-    // lets wait for possible cache cleanup
-    await wait(TEMPLATE_CACHE_GC_TIMEOUT);
+    // lets escape from possible cache cleanup
+	clearTimeout(TemplateCacheCheckTimeout)
+	const cacheCheckerTimeout = 10;
     let cachedItems = Object.keys(TemplatesCache);
     let itemsToAddToCache = TEMPLATE_CACHE_MAX_SIZE - cachedItems.length;
     for (let i = 0; i < itemsToAddToCache; i++) {
         TemplatesCache[`key-${Math.random().toString(36).slice(2)}`] = {};
     }
     assert.equal(Object.keys(TemplatesCache).length, TEMPLATE_CACHE_MAX_SIZE, 'cache is full');
-    checkTemplatesCacheLimit();
-    await wait(TEMPLATE_CACHE_GC_TIMEOUT);
+    checkTemplatesCacheLimit(cacheCheckerTimeout);
+    await wait(cacheCheckerTimeout);
     assert.equal(Object.keys(TemplatesCache).length, TEMPLATE_CACHE_MAX_SIZE, 'cache is full, but not cleaned');
     TemplatesCache[`key-foo-bar`] = {};
     assert.notEqual(Object.keys(TemplatesCache).length, TEMPLATE_CACHE_MAX_SIZE, 'cache size if perfect to clean');
-    checkTemplatesCacheLimit();
-    await wait(TEMPLATE_CACHE_GC_TIMEOUT);
+    checkTemplatesCacheLimit(cacheCheckerTimeout);
+    await wait(cacheCheckerTimeout);
     assert.equal(Object.keys(TemplatesCache).length, 0, 'cache cleaned');
 });


### PR DESCRIPTION
from https://github.com/toranb/ember-cli-hot-loader/pull/92

I have alot of components on page > 300items.

And after `hot-loader` I see some rendering perf issues.
This pr solve rendering speed problem, providing caching for already compiled templates
At this moment cache size is 10k items, don't think we need more.

changes in `addon/components/hot-replacement-component.js`


results before:
![image](https://user-images.githubusercontent.com/1360552/45308781-f47eba80-b52a-11e8-8999-c4836188d26f.png)

results after: 

![image](https://user-images.githubusercontent.com/1360552/45308873-23952c00-b52b-11e8-804d-03211064a547.png)


Idea is:
Before calling `Ember.HTMLBars.compile` we calculate simple template string hash.
And if we have already compiled template for this hash, we reuse it, instead of compiling it one more time.