### PR TITLE
Fix for Assertion Failed: calling set on destroyed object (clean)

### DIFF
--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -99,6 +99,9 @@ const HotReplacementComponent = Component.extend(HotComponentMixin, {
       clearRequirejs(this, baseComponentName);
     }
   },
+  __isAlive() {
+    return  !this.isDestroyed && !this.isDestroying;
+  },
   __rerenderOnTemplateUpdate (modulePath) {
       const baseComponentName = this.get('baseComponentName');
       const wrappedComponentName = this.get('wrappedComponentName');
@@ -112,6 +115,9 @@ const HotReplacementComponent = Component.extend(HotComponentMixin, {
           });
           this.rerender();
           later(() => {
+            if (!this.__isAlive()) {
+                return;
+            }
             this.setProperties({
               wrappedComponentName: wrappedComponentName,
               baseComponentName: baseComponentName


### PR DESCRIPTION
ref https://github.com/toranb/ember-cli-hot-loader/pull/91


Fix for
```
Assertion Failed: calling set on destroyed object: <dreamcatcher-web-app@component:ui/tree-toggler::ember1322>.wrappedComponentName = ui/tree-toggler-original
```

https://github.com/toranb/ember-cli-hot-loader/issues/90