### PR TITLE
[WIP] Custom tag management for components

### DIFF
--- a/addon/components/hot-replacement-component.js
+++ b/addon/components/hot-replacement-component.js
@@ -3,7 +3,6 @@ import { later } from '@ember/runloop';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import HotComponentMixin from 'ember-cli-hot-loader/mixins/hot-component';
-import config from 'ember-get-config';
 
 import clearCache from 'ember-cli-hot-loader/utils/clear-container-cache';
 import clearRequirejs from 'ember-cli-hot-loader/utils/clear-requirejs';
@@ -94,10 +93,7 @@ function getPositionalParamsArray (constructor) {
 
 const HotReplacementComponent = Component.extend(HotComponentMixin, {
   init() {
-    const configuration = config['ember-cli-hot-loader'];
-    const tagless = configuration && configuration['tagless'];
-    const tagName = tagless ? '' : 'div';
-    this.set('tagName', tagName);
+    this.set('tagName', this.get('hotReload').tagNameForComponent(this.get('baseComponentName'), this));
     return this._super();
   },
   parsedName: null,

--- a/addon/services/hot-reload.js
+++ b/addon/services/hot-reload.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import Evented from '@ember/object/evented';
+import config from 'ember-get-config';
 
 /**
   The `willLiveReload` event is fired when we have any JS or HBS changes
@@ -59,5 +60,24 @@ import Evented from '@ember/object/evented';
   @public
 */
 
-
-export default Service.extend(Evented);
+export default Service.extend(Evented, {
+  tagNameForComponent(baseComponentName) {
+    return this._defaultTagNameForComponent(baseComponentName);
+  },
+  _htmlTagNameForComponentByName(baseComponentName) {
+    return baseComponentName.replace(/\//gi,'--');
+  },
+  _defaultTagNameForComponent(baseComponentName) {
+    const configuration = config['ember-cli-hot-loader'];
+    const tagless = configuration && configuration['tagless'];
+    const namedTags = configuration && configuration['named-tags'];
+    if (tagless) {
+      return '';
+    }
+    if (namedTags) {
+      return this._htmlTagNameForComponentByName(baseComponentName);
+    } else {
+      return 'div';
+    }
+  }
+});


### PR DESCRIPTION
This PR allow users to manage wrapper component tagName. 
Now users may specify tag name for wraper to render and force tagless/tagged component behaviour by component name.