### PR TITLE
fix: apply included function with arguments instead of app

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
     return path.relative(this.project.root, require.resolve(npmCompilerPath));
   },
   included: function (app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
     if (app.env === 'production' || app.env === 'test') {
       return;


### PR DESCRIPTION
This is the "recommended" way as seen in https://ember-cli.com/extending/#addon-entry-point .

I'm opening this PR as `this._super.included(app)` it causes some issues with ember-decorators and the next ember-cli-typescript version. 
This will prevent others from having to dive in on why this happens if you try to port your addon to use these addons.